### PR TITLE
HELP: focusInput when console pane activates

### DIFF
--- a/lib/console/console.coffee
+++ b/lib/console/console.coffee
@@ -89,7 +89,7 @@ class Console
       p = p.splitDown()
       p.setFlexScale 1/2
     p.activateItem @view
-    @view.focusInput true
+    p.onDidActivate => setTimeout  => @view.focusInput(true)
 
   toggle: ->
     if atom.workspace.getPaneItems().indexOf(@view) > -1


### PR DESCRIPTION
I'm trying to figure out how to focus on the input line whenever the pane holding the console becomes active. 

To do this I modified `openInTab` to register a callback with the new pane it creates. This callback should call the `focusInput` method on the view whenever the pane becomes active.

I modified `focusInput` to have it log when the function is called, and when it properly finds the last `atom-text-editor`.

From the console log it seems like the function is being called whenever the pane becomes active, but I still can't `focus` on the input line.

Any suggestions? When we figure this out we will just wipe these commits and start a fresh PR.
