### PR TITLE
improve z-ordering of inline results

### DIFF
--- a/lib/editor/results.coffee
+++ b/lib/editor/results.coffee
@@ -5,10 +5,9 @@
 {CompositeDisposable} = require 'atom'
 
 module.exports =
-
   activate: ->
     @subs = new CompositeDisposable()
-
+    @monotypeResults = atom.config.get('ink.monotypeResults')
     @subs.add atom.commands.add 'atom-text-editor:not([mini])',
       'inline-results:clear-current': (e) => @removeCurrent e
       'inline-results:clear-all': => @removeAll()
@@ -28,7 +27,7 @@ module.exports =
     view.classList.add 'ink', 'inline', 'result'
     if error then view.classList.add 'error'
     if clas then view.classList.add clas
-    if atom.config.get('ink.monotypeResults') then view.style.font = 'inherit'
+    if @monotypeResults then view.style.font = 'inherit'
     view.style.position = 'relative'
     view.style.top = -ed.getLineHeightInPixels() + 'px'
     view.style.left = '10px'
@@ -55,7 +54,12 @@ module.exports =
       type: 'overlay'
       item: result.view
     @methods result
-    setTimeout (-> result.view.parentElement.style.pointerEvents = 'none'), 100
+    setTimeout (->
+      result.view.parentElement.style.pointerEvents = 'none'
+      result.view.addEventListener 'click', =>
+        # change natural ordering so that a click brings the current overlay
+        # to the top of the stack:
+        result.view.parentNode.parentNode.appendChild result.view.parentNode), 100
     if !flag
       result.view.classList.add 'ink-hide'
       @timeout 20, =>

--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -32,7 +32,11 @@ module.exports =
       view.visible = true
       icon.removeClass 'icon-chevron-right'
       icon.addClass 'icon-chevron-down'
+      # unfolded results always have z-index of 5 or more so they are on top of
+      # folded results:
+      view[0].parentElement.parentElement.style.zIndex = 5
     else
       view.visible = false
       icon.removeClass 'icon-chevron-down'
       icon.addClass 'icon-chevron-right'
+      view[0].parentElement.parentElement.style.zIndex = ''


### PR DESCRIPTION
fixes https://github.com/JunoLab/atom-ink/issues/9
also: make the monotype-result-thingy I did in a previous commit a bit more performant.
