### PR TITLE
style tweak

### DIFF
--- a/styles/ink.less
+++ b/styles/ink.less
@@ -84,7 +84,6 @@ atom-text-editor::shadow {
   > .tree > .body {
     max-width: 500px;
     max-height: 250px;
-    overflow: auto;
   }
 }
 


### PR DESCRIPTION
let `.ink > .tree > .body` overflow, since `.ink:hover` scrolls.

related to https://github.com/JunoLab/Atom.jl/pull/19.
