### PR TITLE
refactoring and better underline results

### DIFF
--- a/styles/ink.less
+++ b/styles/ink.less
@@ -55,6 +55,7 @@ atom-text-editor::shadow {
   cursor: default;
 
   max-width: 800px;
+  max-height: 400px;
   overflow: hidden;
 
   &:hover {
@@ -63,6 +64,11 @@ atom-text-editor::shadow {
 
   .fade {
     color: @text-color-subtle;
+  }
+
+  &.ink-hide {
+    opacity: 0;
+    transform: translate(10px);
   }
 }
 


### PR DESCRIPTION
This should be fine as is, but I'm PRing it anyways for easier revertability.

Changes in behaviour: `Esc` now also destroys underline results, as does `Clear all results`. Also, the results are animated now.
