### PR TITLE
WIP: Implement block results

### DIFF
--- a/lib/editor/result.coffee
+++ b/lib/editor/result.coffee
@@ -1,6 +1,36 @@
 # TODO: better scrolling behaviour
 {CompositeDisposable} = require 'atom'
 
+# ## Result API
+# `Result`s are DOM elements which represent the result of some operation. They
+# can be created by something like
+#
+# ```coffeescript
+# new ink.Result(ed, range, options)
+# ```
+# where `ed` is the current text editor and `range` is a line range compatible array,
+# e.g. `[3, 4]`. `options` is an object with the mandatory field
+#   `content`: DOM-node that will be diplayed inside of the `Result`.
+# and the optional fields
+# - `error`: Default `false`. If true, adds the `error`-style to the `Result`.
+# - `fade`:  Default `false`. If true, the `Result` will fade in on creation.
+# - `type`:  Default `inline`, can also be `block`. Inline-`Result`s will be
+#            displayed after the end of the last line contained in `range`,
+#            whereas block-`Result`s will be displayed below it and span the
+#            whole width of the current editor.
+#
+# #### Static Methods
+# There are also some static methods provided to deal with `Result`s without
+# addressing a specific object.
+#
+# - `removeLines(start, end, type = 'any')` removes all results with the specified
+# type (or any of them, if no type is given) in the line range `[start, end]`.
+# - `removeAll(ed)` removes all `Result`s in the editor `ed`, which defaults to the
+# currently active editor.
+# - `removeCurrent()` removes all `Result`s for all selected lines in the currently
+# active editor.
+
+
 module.exports =
 class Result
   constructor: (@editor, range, opts={}) ->

--- a/lib/editor/result.coffee
+++ b/lib/editor/result.coffee
@@ -23,9 +23,7 @@ class Result
     switch @type
       when 'inline'
         @view.classList.add 'inline'
-        @view.style.position = 'absolute'
         @view.style.top = -@editor.getLineHeightInPixels() + 'px'
-        @view.style.left = '10px'
       when 'block' then @view.classList.add 'under'
     if error then @view.classList.add 'error'
     # @view.style.pointerEvents = 'auto'

--- a/lib/editor/result.coffee
+++ b/lib/editor/result.coffee
@@ -10,14 +10,15 @@
 # ```
 # where `ed` is the current text editor and `range` is a line range compatible array,
 # e.g. `[3, 4]`. `options` is an object with the mandatory field
-#   `content`: DOM-node that will be diplayed inside of the `Result`.
+# - `content`: DOM-node that will be diplayed inside of the `Result`.
+#
 # and the optional fields
 # - `error`: Default `false`. If true, adds the `error`-style to the `Result`.
 # - `fade`:  Default `false`. If true, the `Result` will fade in on creation.
 # - `type`:  Default `inline`, can also be `block`. Inline-`Result`s will be
-#            displayed after the end of the last line contained in `range`,
-#            whereas block-`Result`s will be displayed below it and span the
-#            whole width of the current editor.
+# displayed after the end of the last line contained in `range`, whereas
+# block-`Result`s will be displayed below it and span the whole width of 
+# the current editor.
 #
 # #### Static Methods
 # There are also some static methods provided to deal with `Result`s without

--- a/styles/ink.less
+++ b/styles/ink.less
@@ -57,6 +57,8 @@ atom-text-editor::shadow {
 
 
 .ink.inline {
+  position: absolute;
+  left: 10px;
 
   &.error {
     color: @text-color-error;

--- a/styles/ink.less
+++ b/styles/ink.less
@@ -40,27 +40,14 @@ atom-text-editor::shadow {
   }
 }
 
-.ink.underline {
-  @inline-background-color: @inset-panel-background-color;
-  background: linear-gradient(to top, darken(@inline-background-color, 5%),
-                                      @inline-background-color 10%,
-                                      @inline-background-color 90%,
-                                      lighten(@inline-background-color, 5%));
-  box-shadow: 0.5px 0.5px 2px @base-border-color;
-  border-radius: 3px;
+.ink.under {
+  font-family: @font-family;
+  color: @text-color;
 
-  padding: 0px 5px 0px 5px;
-  transition: all 0.2s;
-  opacity: 1;
-  cursor: default;
+  background-color: @inset-panel-background-color;
 
-  max-width: 800px;
-  max-height: 400px;
-  overflow: hidden;
-
-  &:hover {
-    overflow: auto;
-  }
+  border-top: 1px solid @syntax-wrap-guide-color;
+  border-bottom: 1px solid @syntax-wrap-guide-color;
 
   &.ink-hide {
     opacity: 0;


### PR DESCRIPTION
This implements block/underline results and only works on Atom master where https://github.com/atom/atom/pull/9930 has been merged.

The first commit just adds another option for `Result` to specify the `Result`'s type. Since the code isn't very nice that way (all those `switch`es...) I decided to implement them as subclasses to `Result`: `inlineResult`, which is the same as the previous `Result`, and `blockResult`, which is the new type of results:

![blockresults](https://cloud.githubusercontent.com/assets/6735977/12599108/7e9cc71e-c48f-11e5-86aa-feff5f5cfc38.PNG)

![blockresults](https://cloud.githubusercontent.com/assets/6735977/12599226/7250f90c-c490-11e5-8c70-c8276d6776d8.PNG)

Notably, the class based approach is a breaking change. 

For example, the code that produced the above images now looks like this:

``` coffeescript
fade = not @ink.results.removeLines editor, range.start.row, range.end.row, 'block'
r = new @ink.blockResult editor, [range.start.row, range.end.row],
```

Still think it's superior -- not sure I can really judge that at this time though :)

ToDos:
- [x] API writeup.
- [ ] Better styling, probably.
- [x] Decide which version to use. _`Result.type` determines the rendering._ 

Open questions:
- [x] Should `activate` and co stay static methods of `Result`? Doesn't make all that much sense imo, but not sure. _They'll stay static methods -- seems easier  that way._
- [x] Should there be a self sufficient `Result` class that would be exported? _--`Result` is exported right now, but doesn't really work on its own.-- Since we'll just go with the construction argument approach, yes._
- [x] Do we want a constructor method that takes the type of the result as an argument?

Just in case someone wants to try this (possibly only relevant on Windows): If you have a stable instance of Atom opened at the same time you want to use the version built from master, strange stuff happens (i.e. the second instance will be the same version as the first, even though it's a completly different executable).
