### PR TITLE
RFC: Implement a modal goto panel

### DIFF
--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -1,0 +1,88 @@
+{$$, SelectListView} = require 'atom-space-pen-views'
+fuzzaldrinPlus = require 'fuzzaldrin-plus'
+
+# ## GoToDef-Panel
+#
+# `goto` takes a promise as its argument, which can either be fulfilled or rejected.
+# Both modes will be handled by `goto` as follows:
+# On fulfillment, a `goToView` will be shown and populated by the array `items`
+# returned by the promise.
+#   `items` conatins objects with the fields:
+#     .text:      Displayed text, searchable.
+#     .file:      File in which this method is defined, not displayed.
+#     .line:      Line of definition.
+#     .dispfile:  Humanized file path, displayed.
+#
+# On rejection, the `goToView` will only shown the error message provided.
+
+module.exports =
+goto: (promise) ->
+  @view ?= new MethodView()
+  @view.setLoading "Loading..."
+  @view.show()
+  promise.then (items) -> @view.setItems(items),
+               (error) -> @view.setError(error)
+
+class goToView extends SelectListView
+  initialize: ->
+    super
+    @panel = atom.workspace.addModalPanel(item: this, visible: false)
+    @addClass('command-palette')
+    @addClass('method-panel')
+
+  destroy: ->
+    @cancel()
+    @panel.destroy()
+
+  # Create the view for one item.
+  viewForItem: ({text, dispfile, line}) ->
+    # the highlighting is taken verbatim from https://github.com/atom/command-palette
+    filterQuery = @getFilterQuery()
+    matches = fuzzaldrinPlus.match(text, filterQuery)
+
+    $$ ->
+      highlighter = (command, matches, offsetIndex) =>
+        lastIndex = 0
+        matchedChars = [] # Build up a set of matched chars to be more semantic
+
+        for matchIndex in matches
+          matchIndex -= offsetIndex
+          continue if matchIndex < 0 # If marking up the basename, omit command matches
+          unmatched = command.substring(lastIndex, matchIndex)
+          if unmatched
+            @span matchedChars.join(''), class: 'character-match' if matchedChars.length
+            matchedChars = []
+            @text unmatched
+          matchedChars.push(command[matchIndex])
+          lastIndex = matchIndex + 1
+
+        @span matchedChars.join(''), class: 'character-match' if matchedChars.length
+
+        # Remaining characters are plain text
+        @text command.substring(lastIndex)
+
+      @li class: 'two-lines', =>
+        @div class: 'primary-line', -> highlighter(text, matches, 0)
+        @div dispfile + ":" + line, class: 'secondary-line'
+
+  # Only `item.text` is searchable.
+  getFilterKey: -> 'text'
+
+  # Show the goto-panel and store the previously focused element.
+  show: () ->
+    @storeFocusedElement()
+    @panel.show()
+    @focusFilterEditor()
+
+  hide: () ->
+    @panel?.hide()
+
+  # Jump to `item.file` at line `item.line`, when an item was selected.
+  confirmed: (item) ->
+    atom.workspace.open item.file,
+      initialLine: item.line
+    @hide()
+
+  # Return to previously focused element when the modal panel is cancelled.
+  cancelled: ->
+    @hide()

--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -21,11 +21,11 @@ fuzzaldrinPlus = require 'fuzzaldrin-plus'
 
 
 module.exports =
-goto: (symbolTable) ->
+goto: (symbolTableOrPromise) ->
   @view ?= new GotoView()
 
-  # this allows either a promise or a result as the input
-  promise = Promise.resolve symbolTable
+  # this allows either a promise or a symbolTable as the input
+  promise = Promise.resolve symbolTableOrPromise
 
   promise.then (symbolTable) =>
     if symbolTable.error

--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -14,23 +14,23 @@ fuzzaldrinPlus = require 'fuzzaldrin-plus'
 #     .line:      Line of definition.
 #     .dispfile:  Humanized file path, displayed.
 #
-# On rejection, the `GotoView` will only show the error message provided.
+# If the Promise errors, it should contain an object with the field error, which
+# will subsequently be displayed in a modal panel.
 
 module.exports =
 goto: (promise) ->
   @view ?= new GotoView()
 
   promise
-    .then (items) ->
+    .then (items) =>
+      if items.error?
+        @view.setError items.error
+        @view.show()
       if items.length == 1
         GotoView.openItem items[0]
       else if items.length > 1
         @view.setItems items
         @view.show()
-
-    .catch (error) ->
-      @view.setError error
-      @view.show()
 
 class GotoView extends SelectListView
   initialize: ->

--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -1,20 +1,20 @@
 {$$, SelectListView} = require 'atom-space-pen-views'
 fuzzaldrinPlus = require 'fuzzaldrin-plus'
-loading = require 'util/loading'
 
 # ## GoToDef-Panel
 #
 # `goto` takes a promise as its argument, which can either be fulfilled or rejected.
 # Both modes will be handled by `goto` as follows:
-# On fulfillment, a `goToView` will be shown and populated by the array `items`
-# returned by the promise.
+# On fulfillment, a `GotoView` will be shown and populated by the array `items`
+# returned by the promise if there's more than one item in it. Otherwise, Atom
+# jumps straight to the definition.
 #   `items` conatins objects with the fields:
 #     .text:      Displayed text, searchable.
 #     .file:      File in which this method is defined, not displayed.
 #     .line:      Line of definition.
 #     .dispfile:  Humanized file path, displayed.
 #
-# On rejection, the `GotoView` will only shown the error message provided.
+# On rejection, the `GotoView` will only show the error message provided.
 
 module.exports =
 goto: (promise) ->
@@ -30,6 +30,7 @@ goto: (promise) ->
 
     .catch (error) ->
       @view.setError error
+      @view.show()
 
 class GotoView extends SelectListView
   initialize: ->

--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -20,8 +20,8 @@ goto: (promise) ->
   @view ?= new MethodView()
   @view.setLoading "Loading..."
   @view.show()
-  promise.then (items) -> @view.setItems(items),
-               (error) -> @view.setError(error)
+  promise.then ((items) -> @view.setItems items),
+                (error) -> @view.setError error
 
 class goToView extends SelectListView
   initialize: ->

--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -23,16 +23,15 @@ module.exports =
 goto: (promise) ->
   @view ?= new GotoView()
 
-  promise
-    .then (result) =>
-      if result.error
-        @view.setError result.items
-        @view.show()
-      else if result.items.length == 1
-        GotoView.openItem result.items[0]
-      else if result.items.length > 1
-        @view.setItems result.items
-        @view.show()
+  promise.then (result) =>
+    if result.error
+      @view.setError result.items
+      @view.show()
+    else if result.items.length == 1
+      GotoView.openItem result.items[0]
+    else if result.items.length > 1
+      @view.setItems result.items
+      @view.show()
 
 class GotoView extends SelectListView
   initialize: ->

--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -28,7 +28,7 @@ class goToView extends SelectListView
     super
     @panel = atom.workspace.addModalPanel(item: this, visible: false)
     @addClass('command-palette')
-    @addClass('method-panel')
+    @addClass('gotodef-panel')
 
   destroy: ->
     @cancel()

--- a/lib/gotodef.coffee
+++ b/lib/gotodef.coffee
@@ -3,34 +3,38 @@ fuzzaldrinPlus = require 'fuzzaldrin-plus'
 
 # ## GoToDef-Panel
 #
-# `goto` takes a promise as its argument, which can either be fulfilled or rejected.
-# Both modes will be handled by `goto` as follows:
-# On fulfillment, a `result` object is returned which contains two fields:
+# `goto` either takes a `symbolTable` as its argument, or a Promise which returns a
+# `symbolTable`.
 #
-#   - `result.error`: Boolean. If true, the contents of `result.items` will be
-#   shown as an error.
+# A `symbolTable` is specified by having the following fields:
 #
-#   - `result.items` -  Array that contains objects with the fields
+#   - `symbolTable.error`: Boolean. If true, the contents of `result.items` will
+#   be shown as an error.
+#
+#   - `symbolTable.items` -  Array that contains objects with the fields
 #     - `.text` -       Displayed text, searchable.
 #     - `.file` -       File in which this method is defined, not displayed.
 #     - `.line` -       Line of definition.
 #     - `.dispfile` -   Humanized file path, displayed.
 #
-#   or a plain text string if `result.error` is true.
+#   or a plain text string if `symbolTable.error` is true.
 
 
 module.exports =
-goto: (promise) ->
+goto: (symbolTable) ->
   @view ?= new GotoView()
 
-  promise.then (result) =>
-    if result.error
-      @view.setError result.items
+  # this allows either a promise or a result as the input
+  promise = Promise.resolve symbolTable
+
+  promise.then (symbolTable) =>
+    if symbolTable.error
+      @view.setError symbolTable.items
       @view.show()
-    else if result.items.length == 1
-      GotoView.openItem result.items[0]
-    else if result.items.length > 1
-      @view.setItems result.items
+    else if symbolTable.items.length == 1
+      GotoView.openItem symbolTable.items[0]
+    else if symbolTable.items.length > 1
+      @view.setItems symbolTable.items
       @view.show()
 
 class GotoView extends SelectListView

--- a/lib/ink.coffee
+++ b/lib/ink.coffee
@@ -8,7 +8,7 @@ Console = require './console/console'
 PlotPane = require './plots/pane'
 Workspace = require './workspace/workspace'
 tree = require './tree'
-goto    = require './gotodef'
+goto = require './gotodef'
 
 module.exports = Ink =
   activate: ->

--- a/lib/ink.coffee
+++ b/lib/ink.coffee
@@ -8,6 +8,7 @@ Console = require './console/console'
 PlotPane = require './plots/pane'
 Workspace = require './workspace/workspace'
 tree = require './tree'
+goto    = require './gotodef'
 
 module.exports = Ink =
   activate: ->
@@ -38,3 +39,4 @@ module.exports = Ink =
     PlotPane: PlotPane
     highlights: highlights
     tree: tree
+    goto: goto

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.0"
+    "atom-space-pen-views": "^2.0.0",
+    "fuzzaldrin-plus": "^0.1.0"
   },
   "providedServices": {
     "ink": {

--- a/styles/ink.less
+++ b/styles/ink.less
@@ -116,3 +116,18 @@ atom-text-editor::shadow {
 ink-console .ink.tree > .icon {
   position: absolute;
 }
+
+.gotodef-panel {
+  .two-lines {
+    padding: 0.2em 0.75em 0.2em 1em !important;
+    .primary-line, .secondary-line {
+      line-height: 1.8em;
+    }
+  }
+  .error-message {
+    color: @text-color-error;
+  }
+  .character-match {
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
Pretty much [this](https://github.com/JunoLab/atom-julia-client/pull/82), except more general.

I'm not quire sure how to handle the case when only one item exists -- we can't know that before the promise is fulfilled, and that should arguably only happen _after_ the goto-panel is displayed. It'd be a bit awkward to close it right after and jump straight to the def.

ToDo:
- [ ] Specs!
