### PR TITLE
switch to using the default atom buffer IDs instead of inkIDs

### DIFF
--- a/lib/editor/highlights.coffee
+++ b/lib/editor/highlights.coffee
@@ -2,7 +2,7 @@ module.exports =
   matchesPath: (ed, path) ->
     ed.getPath() == path ||
       (!ed.getPath() &&
-        ed.getBuffer().inkId.toString() == path.match(/untitled-(\d*)/)?[1])
+        ed.getBuffer().id.toString() == path.match(/untitled-(\d*)/)?[1])
 
   observeLines: (ls, f) ->
     atom.workspace.observeTextEditors (ed) =>

--- a/lib/ink.coffee
+++ b/lib/ink.coffee
@@ -17,11 +17,6 @@ module.exports = Ink =
     PlotPane.activate()
     Workspace.activate()
 
-    edId = 1
-    atom.workspace.observeTextEditors (ed) ->
-      if not ed.getPath()?
-        ed.getBuffer().inkId ?= edId++
-
     try
       if id = localStorage.getItem 'metrics.userId'
         http.get "http://data.junolab.org/hit?id=#{id}&app=ink"


### PR DESCRIPTION
ref: https://github.com/JunoLab/atom-julia-client/pull/123

~~should fix #37.~~ Actually, no, it doesn't. Still a sensible change imo.
