### PR TITLE
Fixed #43 - Improving tree view creation

### DIFF
--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -7,12 +7,22 @@ module.exports =
         @span class: 'icon icon-chevron-right'
         @div class: 'header gutted'
         @div class: 'body gutted'
-    view.find('> .header').append head
-    view.find('> .body').append child for child in children
 
-    view.find('> .body').hide() unless expand
+    # Setup the header
+    header = view.find('> .header')
+    header.append head
+    header.click => @toggle view
+
+    # Setup the body
+    body = view.find('> .body')
+    body.hide() unless expand
+    # Add the children to the body. Using direct dom manipulation instead of
+    # jQuery to improve performance in the presence of many children.
+    realBody = body[0]
+    for child in children
+      realBody.appendChild child
+
     view.find('> .icon').click => @toggle view
-    view.find('> .header').click => @toggle view
 
     view[0]
 


### PR DESCRIPTION
This uses direct DOM manipulation instead of jQuery to provide better performance. 

Performance before change for creating a tree view with N children:
- 1000 - 59 ms
- 10000 - 1451 ms
- 100000 - 132278 ms

Performance after the change is:
- 1000 - 5 ms
- 10000 - 27 ms
- 100000 - 216 ms

Note that I accidentally used the wrong issue number in my commit message.
