### PR TITLE
make results unremovable while loading

### DIFF
--- a/lib/editor/result.coffee
+++ b/lib/editor/result.coffee
@@ -56,7 +56,7 @@ class Result
     switch @type
       when 'inline'
         @view.classList.add 'inline'
-        atom.config.observe 'editor.lineHeight', (h) =>
+        @disposables.add atom.config.observe 'editor.lineHeight', (h) =>
           @view.style.top = -h + 'em';
       when 'block'  then @view.classList.add 'under'
     # @view.style.pointerEvents = 'auto'
@@ -74,6 +74,7 @@ class Result
     if loading then @setContent views.render(span 'loading icon icon-gear'), opts
 
   setContent: (view, {error, loading}={}) ->
+    @loading = loading
     while @view.firstChild?
       @view.removeChild @view.firstChild
     if error then @view.classList.add 'error' else @view.classList.remove 'error'
@@ -98,6 +99,7 @@ class Result
     trees.toggle $(@view).find('> .tree')
 
   remove: ->
+    if @loading then return
     @view.classList.add 'ink-hide'
     @timeout 200, => @destroy()
 


### PR DESCRIPTION
and add the settings listener to our disposables.

@MikeInnes: What do you think of that change in behvaiour? While I _think_ it's sensible to have it like this, I'm not totally sure, so I wanted to run this by you before merging.
