### PR TITLE
shortcuts for navigating through results

### DIFF
--- a/keymaps/ink.cson
+++ b/keymaps/ink.cson
@@ -24,3 +24,9 @@
 '.platform-win32 atom-text-editor:not([mini]),
  .platform-linux atom-text-editor:not([mini])':
   'ctrl-i ctrl-c': 'inline-results:clear-all'
+
+'atom-overlay .ink':
+  't': 'inline-results:toggleTree'
+  'enter': 'native!'
+  'tab': 'native!'
+  'shift-tab': 'native!'

--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -4,7 +4,7 @@ views = require './util/views'
 
 module.exports =
   treeView: (head, children, {expand}) ->
-    view = views.render div 'ink tree', [
+    view = views.render div {class: 'ink tree', 'tabindex': '0'}, [
       span 'icon icon-chevron-right open'
       div 'header gutted', head
       div 'body gutted', children

--- a/styles/ink.less
+++ b/styles/ink.less
@@ -20,6 +20,12 @@ atom-text-editor {
   pointer-events: none;
 }
 
+atom-overlay:last-child .ink.inline {
+  background-color: contrast(@syntax-background-color,
+                             darken(@syntax-background-color, 4%),
+                             lighten(@syntax-background-color, 4%));
+}
+
 atom-text-editor::shadow {
   div.block-notify .region {
     background: @background-color-info;
@@ -80,6 +86,12 @@ atom-text-editor::shadow {
   position: relative;
   left: 10px;
 
+  :focus {
+    > .icon:before {
+      text-shadow: 2px 2px 0 @background-color-info;
+    }
+  }
+
   pointer-events: auto;
 
   &.error {
@@ -87,12 +99,11 @@ atom-text-editor::shadow {
     border-left: 2px solid @background-color-error;
   }
 
-  background: contrast(@syntax-background-color,
-                       darken(@syntax-background-color, 4%),
-                       lighten(@syntax-background-color, 4%));
+  background: @syntax-background-color;
   border-left: 2px solid @background-color-info;
-  border-right: 2px solid @syntax-background-color;
-
+  border-right: 2px solid contrast(@syntax-background-color,
+                            darken(@syntax-background-color, 4%),
+                           lighten(@syntax-background-color, 4%));
   border-radius: 3px;
 
   padding: 0px 5px 0px 5px;


### PR DESCRIPTION
Preview:
![treetoggling](https://cloud.githubusercontent.com/assets/6735977/16040710/a1d22304-3231-11e6-873f-308db1dda355.gif)

This is a bit minimalistic and I don't know if everything works as expected, so I'd appreciate someone trying this.

Also, there's no keybinding for focusing results yet -- I'm using `Ctrl-i Ctrl-f` right now and it feels okayish.
