### PR TITLE
improve console autoscrolling

### DIFF
--- a/lib/console/view.coffee
+++ b/lib/console/view.coffee
@@ -30,6 +30,9 @@ class ConsoleElement extends HTMLElement
     @onfocus = =>
       if document.activeElement == this and @model.getInput()
         @focusLast()
+    # start listening now, since @lock doesn't work properly if @items is empty
+    @resizer.listenTo @items, =>
+      @scrollTop = @scrollHeight
     for item in @model.items
       @addItem item
     atom.config.observe 'editor.fontFamily', (value) =>
@@ -191,8 +194,7 @@ class ConsoleElement extends HTMLElement
   # Scrolling
 
   lock: (f) ->
-    last = @lastDivider()
-    if @isVisible last
+    if @isVisible @lastDivider()
       # listen to changes in height from subtree modifications
       @resizer.listenTo @items, =>
         @scrollTop = @scrollHeight

--- a/lib/console/view.coffee
+++ b/lib/console/view.coffee
@@ -1,3 +1,5 @@
+ResizeDetector = require 'element-resize-detector'
+
 class ConsoleElement extends HTMLElement
 
   createdCallback: ->
@@ -17,6 +19,7 @@ class ConsoleElement extends HTMLElement
 
   initialize: (@model) ->
     @getModel = -> @model
+    @resizer = ResizeDetector strategy: "scroll"
     @model.onDidAddItem (item) => @addItem item
     @model.onDidInsertItem ([item, i]) => @insertItem [item, i]
     @model.onDidClear => @clear()
@@ -188,14 +191,15 @@ class ConsoleElement extends HTMLElement
   # Scrolling
 
   lock: (f) ->
-    last = @lastCell()
+    last = @lastDivider()
     if @isVisible last
-      target = last.offsetTop + last.clientHeight - @scrollTop
+      # listen to changes in height from subtree modifications
+      @resizer.listenTo @items, =>
+        @scrollTop = @scrollHeight
       f()
-      last = @lastCell()
-      delta = last.offsetTop + last.clientHeight - @scrollTop - target
-      @scrollTop += delta
+      @scrollTop = @scrollHeight
     else
+      @resizer.removeAllListeners @items
       f()
 
 module.exports = ConsoleElement = document.registerElement 'ink-console', prototype: ConsoleElement.prototype

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "fuzzaldrin-plus": "^0.1.0",
-    "underscore-plus": "*"
+    "underscore-plus": "*",
+    "element-resize-detector": "*"
   },
   "providedServices": {
     "ink": {


### PR DESCRIPTION
Fixes #66.

This is only mostly correct, as the resize listener (`@resizer`) can only be removed on item insertion, so if you scroll up a bit and then change some item's height (expand a tree for example), the console will still auto scroll to the bottom.
