### PR TITLE
Add ANSI codes on stdout and stderr

### DIFF
--- a/lib/console/view.coffee
+++ b/lib/console/view.coffee
@@ -1,3 +1,6 @@
+AnsiConverter = require('ansi-to-html')
+converter = new AnsiConverter()
+
 class ConsoleElement extends HTMLElement
 
   createdCallback: ->
@@ -146,17 +149,22 @@ class ConsoleElement extends HTMLElement
   updateGrammar: ({editor, grammar}) ->
     editor.setGrammar atom.grammars.grammarForScopeName grammar
 
-  streamView: (item, type) ->
+  streamView: (item, type, ansi) ->
     out = document.createElement 'div'
     out.innerText = item.text
+    out.innerHTML = converter.toHtml(out.innerHTML) if ansi
+
     @observeKey item, 'text', (text) =>
-      @lock -> out.innerText = text
+      @lock ->
+        out.innerText = text
+        out.innerHTML = converter.toHtml(out.innerHTML) if ansi
+
     out.classList.add type, 'stream'
     out
 
-  stdoutView: (item) -> @streamView item, 'output'
+  stdoutView: (item) -> @streamView item, 'output', true
 
-  stderrView: (item) -> @streamView item, 'err'
+  stderrView: (item) -> @streamView item, 'err', true
 
   infoView: (item) -> @streamView item, 'info'
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
+    "ansi-to-html": "^0.4.1",
     "atom-space-pen-views": "^2.0.0",
     "fuzzaldrin-plus": "^0.1.0",
     "underscore-plus": "*"


### PR DESCRIPTION
I'm working with Clojure, with proto-repl. When I work with midje and other test libraries that colorize outputs, my text becomes **very** garbled and sometimes I'm not even able to find out what's wrong.

(before)
![image](https://cloud.githubusercontent.com/assets/138037/17680036/a4746162-6314-11e6-805a-b08da9a101a7.png)

This PR adds a new dependency (because ANSI parsing is kinda hard) and wire it to stdout and stderr, so the same colors that would appear on terminal will appear in the console:

(after)
![image](https://cloud.githubusercontent.com/assets/138037/17680162/4058997c-6315-11e6-8546-4a4f7bbdb855.png)
