### PR TITLE
Result block stylesheet improvements

### DIFF
--- a/styles/ink.less
+++ b/styles/ink.less
@@ -69,20 +69,43 @@ atom-text-editor::shadow {
 // TODO: more CSS sharing
 
 .ink.under {
-  font-family: @font-family;
-  color: @text-color;
-
-  cursor: default;
+  padding: @component-padding * 0.5;
+  background-color: darken(@syntax-background-color, 5%);
+  font-size: 0.9em;
+  border: none;
+  border-radius: @component-border-radius;
+  border-left: 0.15em solid @background-color-info;
+  color: @syntax-text-color;
 
   &.error {
-    color: @text-color-error;
+    border-left-color: @background-color-error;
+    color: lighten(@background-color-error, 10%);
   }
 
-  background-color: @inset-panel-background-color;
+  &.ink-hide {
+    height: 0;
+  }
 
-  border-top: 1px solid @syntax-wrap-guide-color;
-  border-bottom: 1px solid @syntax-wrap-guide-color;
-  padding-left: 5px;
+  &.invalid {
+    opacity: 0.5;
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  &.loading {
+    opacity: 0.5;
+    .icon:before {
+      height: initial;
+      width: initial;
+      animation: spin 4s linear infinite;
+      @keyframes spin { 100% { transform: rotate(1turn); } }
+    }
+  }
+
+  .fade {
+    color: lighten(@syntax-text-color, 20%);
+  }
 }
 
 

--- a/styles/ink.less
+++ b/styles/ink.less
@@ -66,58 +66,8 @@ atom-text-editor::shadow {
   }
 }
 
-// TODO: more CSS sharing
-
-.ink.under {
-  padding: @component-padding * 0.5;
-  background-color: darken(@syntax-background-color, 5%);
-  font-size: 0.9em;
-  border: none;
-  border-radius: @component-border-radius;
-  border-left: 0.15em solid @background-color-info;
-
-  &.error {
-    border-left-color: @background-color-error;
-    color: lighten(@background-color-error, 10%);
-  }
-
-  &.ink-hide {
-    height: 0;
-  }
-
-  &.invalid {
-    opacity: 0.5;
-    &:hover {
-      opacity: 1;
-    }
-  }
-
-  &.loading {
-    opacity: 0.5;
-    .icon:before {
-      height: initial;
-      width: initial;
-      animation: spin 4s linear infinite;
-      @keyframes spin { 100% { transform: rotate(1turn); } }
-    }
-  }
-
-  .fade {
-    color: lighten(@syntax-text-color, 20%);
-  }
-
-  a {
-    color: @syntax-text-color;
-    opacity: 0.60;
-  }
-}
-
-
-.ink.inline {
+.result-mixin() {
   color: @syntax-text-color;
-  position: relative;
-  left: 1em;
-
   pointer-events: auto;
 
   &.error {
@@ -125,11 +75,10 @@ atom-text-editor::shadow {
     border-left: 2px solid @background-color-error;
   }
 
-  background: @syntax-background-color;
   border-left: 2px solid @background-color-info;
   border-right: 2px solid contrast(@syntax-background-color,
-                             darken(@syntax-background-color, 4%),
-                             lighten(@syntax-background-color, 4%));
+                                   darken(@syntax-background-color, 4%),
+                                   lighten(@syntax-background-color, 4%));
 
   border-radius: 3px;
 
@@ -138,12 +87,16 @@ atom-text-editor::shadow {
   opacity: 1;
   cursor: default;
 
-  max-width: 400px;
   overflow: hidden;
   white-space: pre;
 
   * {
     vertical-align: top;
+  }
+
+  a {
+    color: @syntax-text-color;
+    opacity: 0.65;
   }
 
   p {
@@ -184,9 +137,7 @@ atom-text-editor::shadow {
       opacity: 1;
     }
   }
-  > .tree > .body {
-    max-height: 250px;
-  }
+
 
   .editor.editor-colors {
     color: @syntax-text-color;
@@ -195,6 +146,29 @@ atom-text-editor::shadow {
     background: none;
     padding: 0;
   }
+}
+
+.ink.inline {
+  .result-mixin;
+  background: @syntax-background-color;
+  position: relative;
+  left: 1em;
+  max-width: 400px;
+
+  > .tree > .body {
+    max-height: 250px;
+  }
+}
+
+.ink.under {
+  .result-mixin;
+  background: contrast(@syntax-background-color,
+                       darken(@syntax-background-color, 3%),
+                       lighten(@syntax-background-color, 3%));
+  font-size: 0.9em;
+  max-width: 100%;
+  white-space: pre-line;
+  padding: 0.5em 0.5em 0.5em 1em;
 }
 
 .ink.stepper {

--- a/styles/ink.less
+++ b/styles/ink.less
@@ -75,7 +75,6 @@ atom-text-editor::shadow {
   border: none;
   border-radius: @component-border-radius;
   border-left: 0.15em solid @background-color-info;
-  color: @syntax-text-color;
 
   &.error {
     border-left-color: @background-color-error;
@@ -105,6 +104,11 @@ atom-text-editor::shadow {
 
   .fade {
     color: lighten(@syntax-text-color, 20%);
+  }
+
+  a {
+    color: @syntax-text-color;
+    opacity: 0.60;
   }
 }
 


### PR DESCRIPTION
Currently, block results uses the Atom UI theme for color information. 
![screen shot 2016-11-19 at 9 34 43 pm](https://cloud.githubusercontent.com/assets/3378450/20460502/45ae95d8-aea2-11e6-83e4-95865d8c83ab.png)
This changes the stylesheet to use the Atom Syntax colors instead. It also styles block results to look more like inline results.
![screen shot 2016-11-19 at 9 33 05 pm](https://cloud.githubusercontent.com/assets/3378450/20460505/55c8b020-aea2-11e6-83be-682f7300d2e3.png)
![screen shot 2016-11-19 at 9 32 42 pm](https://cloud.githubusercontent.com/assets/3378450/20460506/5776c312-aea2-11e6-8742-83a97b2d4cfd.png)