### PR TITLE
fixed typo in keymaps.cson: shift-space unset!

### DIFF
--- a/keymaps/ink.cson
+++ b/keymaps/ink.cson
@@ -14,7 +14,7 @@
 'ink-console':
   'alt-up': 'console:previous-in-history'
   'alt-down': 'console:next-in-history'
-  'shift-space': '!unset'
+  'shift-space': 'unset!'
 
 'atom-text-editor:not([mini])':
   'escape': 'inline:clear-current'


### PR DESCRIPTION
Pretty sure `!unset` should be `unset!`. Reference commit 2ccdd863dcb460c33f7ce55a672c97b556a819f2