### PR TITLE
turn off css animations

### DIFF
--- a/styles/ink.less
+++ b/styles/ink.less
@@ -14,7 +14,8 @@ atom-text-editor {
 }
 
 progress.ink:indeterminate {
-  animation-iteration-count: infinite;
+  animation: none;
+  // animation-iteration-count: infinite;
 }
 
 .ink .markdown {
@@ -234,10 +235,10 @@ atom-text-editor {
 
   &.loading {
     opacity: 0.5;
-    .icon:before {
-      animation: spin 4s linear infinite;
-      @keyframes spin { 100% { transform: rotate(1turn); } }
-    }
+    // .icon:before {
+    //   animation: spin 4s linear infinite;
+    //   @keyframes spin { 100% { transform: rotate(1turn); } }
+    // }
   }
 
   &.ink-hide, &.ink-hide.invalid {

--- a/styles/ink.less
+++ b/styles/ink.less
@@ -13,11 +13,6 @@ atom-text-editor {
   clip: rect(auto auto auto auto); // Otherwise inline results spill everywhere
 }
 
-progress.ink:indeterminate {
-  animation: none;
-  // animation-iteration-count: infinite;
-}
-
 .ink .markdown {
   font-family: 'BlinkMacSystemFont', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
   pre {
@@ -392,14 +387,14 @@ atom-text-editor {
 
 .ink-tooltip {
   position: absolute;
-  background: contrast(@syntax-background-color,
-                       darken(@syntax-background-color, 4%),
-                       lighten(@syntax-background-color, 4%));
+  background: contrast(@app-background-color,
+                       darken(@app-background-color, 4%),
+                       lighten(@app-background-color, 4%));
   border-left: 2px solid @background-color-info;
   border-right: 2px solid @background-color-info;
   border-radius: 3px;
   font-size: 1.15em;
-  color: @syntax-text-color;
+  color: @text-color;
   padding: 0.5em;
   z-index: 100;
   opacity: 1;
@@ -415,10 +410,6 @@ atom-text-editor {
 
 .ink-tooltip-msg {
   display: block;
-}
-
-.progress-tr {
-  padding: 0 0.2em;
 }
 
 .xterm .xterm-viewport {

--- a/styles/progress.less
+++ b/styles/progress.less
@@ -1,0 +1,39 @@
+@import "ui-variables";
+
+@progress-height: 8px;
+@progress-background-color: @text-color-info;
+@progress-buffer-color: fade(@text-color-info, 20%);
+
+.progress-tr {
+  padding: 0 0.2em;
+}
+
+progress.ink {
+  -webkit-appearance: none;
+  height: @progress-height;
+  border-radius: 2px;
+  background-color: @input-background-color;
+  box-shadow: inset 0 0 0 1px @input-border-color;
+
+  &::-webkit-progress-bar {
+    background-color: transparent;
+  }
+
+  &::-webkit-progress-value {
+    border-radius: 2px;
+    background-color: @progress-background-color;
+  }
+
+  // Is buffering (when no value is set)
+  &:indeterminate {
+    background-image:
+       linear-gradient(-45deg, transparent 33%, @progress-buffer-color 33%,
+                               @progress-buffer-color 66%, transparent 66%);
+    background-size: 25px @progress-height, 100% 100%, 100% 100%;
+    animation: none;
+  }
+
+  &[value] {
+    background-color: @input-background-color;
+  }
+}


### PR DESCRIPTION
This turns off the spinning cog for in-editor results as well as the animation for indeterminate progress bars on certain themes. Seems to completely elimnate any performance issues Juno might have locally and doesn't look *that* bad at all, imho.

If anyone has better ideas that don't look horrible, I'm all ears :)

Fixes #142.