### PR TITLE
add a "forget all plots" button in the plot pane

### DIFF
--- a/lib/plots/pane.js
+++ b/lib/plots/pane.js
@@ -47,7 +47,10 @@ export default class PlotPane extends PaneItem {
         <Button icon='arrow-left' alt='Previous' disabled = {this.currentItem <= 0} onclick={() => this.previousPlot()}/>
         <Button icon='arrow-right' alt='Next'  disabled = {this.currentItem >= (this.items.length - 1)} onclick={() => this.nextPlot()}/>
       </div>,
-      <Button icon='circle-slash' alt='Forget Plot' disabled = {currentItem == undefined} onclick={() => this.teardown()} />
+      <div className='btn-group'>
+        <Button icon='circle-slash' alt='Forget Plot' disabled = {currentItem == undefined} onclick={() => this.teardown()} />
+        <Button icon='circle-slash' alt='Forget All Plots' disabled = {currentItem == undefined} onclick={() => this.teardownAll()} />
+      </div>
     ];
     if (currentItem && currentItem.toolbar) buttons = buttons.concat(toView(currentItem.toolbar))
 
@@ -127,6 +130,12 @@ export default class PlotPane extends PaneItem {
       this.activateItem(this.items.length - 1)
     } else {
       this.activateItem(this.currentItem)
+    }
+  }
+
+  teardownAll () {
+    while (this.items[this.currentItem]){
+      this.teardown()
     }
   }
 


### PR DESCRIPTION
Hi,

I added a button "forget all plots" in the plot pane:
![forget_all_plots](https://user-images.githubusercontent.com/41587227/43091309-093184fa-8eaa-11e8-8e9c-1a4a0dc02e28.png)

I am far far away to be an expert of JS (first JS code), but here are the intended behavior: decrease the memory consumption (e.g. when performing live plotting).

Thank you in advance to take this feature into account.