### PR TITLE
WIP: Integrate the find-and-replace panel with the Julia Console

### DIFF
--- a/keymaps/ink.cson
+++ b/keymaps/ink.cson
@@ -49,12 +49,12 @@
 '.platform-win32 ink-terminal, .platform-linux ink-terminal':
   'ctrl-shift-c': 'ink-terminal:copy'
   'ctrl-shift-v': 'ink-terminal:paste'
-  'ctrl-shift-f': 'ink-terminal:search'
+  'ctrl-shift-f': 'ink-terminal:show-search'
 
 '.platform-darwin ink-terminal':
   'cmd-c': 'ink-terminal:copy'
   'cmd-v': 'ink-terminal:paste'
-  'cmd-f': 'ink-terminal:search'
+  'cmd-f': 'ink-terminal:show-search'
 
 'ink-terminal .search .searchinput atom-text-editor':
   'enter': 'ink-terminal:find-next'

--- a/keymaps/ink.cson
+++ b/keymaps/ink.cson
@@ -49,7 +49,14 @@
 '.platform-win32 ink-terminal, .platform-linux ink-terminal':
   'ctrl-shift-c': 'ink-terminal:copy'
   'ctrl-shift-v': 'ink-terminal:paste'
+  'ctrl-shift-f': 'ink-terminal:search'
 
 '.platform-darwin ink-terminal':
   'cmd-c': 'ink-terminal:copy'
   'cmd-v': 'ink-terminal:paste'
+  'cmd-f': 'ink-terminal:search'
+
+'ink-terminal .search .searchinput atom-text-editor':
+  'enter': 'ink-terminal:find-next'
+  'shift-enter': 'ink-terminal:find-previous'
+  'escape': 'ink-terminal:close-search'

--- a/lib/console2/console.js
+++ b/lib/console2/console.js
@@ -118,9 +118,11 @@ export default class InkTerminal extends PaneItem {
 
     // TODO: Make this one talk to xterm!
     this.buffer.scanInRange = function(regex, range, iterator) {
-      thisTerminal._do_search_in_range(regex,range)
-      // Pretend there was a valid result so that findNext will work!
-      return new TextBuffer("aaa").scanInRange(RegExp("a"),range,iterator)
+      let foundMatch = thisTerminal._do_search_in_range(regex,range)
+      if (foundMatch) {
+        // Pretend there was a valid result so that findNext will work!
+        return new TextBuffer("aaa").scanInRange(RegExp("a"),range,iterator)
+      }
     }
   }
 
@@ -258,9 +260,10 @@ export default class InkTerminal extends PaneItem {
   //   https://github.com/atom/find-and-replace/blob/71a80c0b793423e7166fd26c2f39e932b9b5cd14/lib/buffer-search.js#L35
 
   // Search the Terminal through xterm.js!
+  // Returns: Whether a result was found.
   _do_search_in_range(regex, range) {
     this._lastRegex = regex
-    search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
+    return search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
   }
 
   // Repeat the call to findNext in xterm.js

--- a/lib/console2/console.js
+++ b/lib/console2/console.js
@@ -3,7 +3,7 @@
 
 import etch from 'etch'
 import { Raw } from '../util/etch.js'
-import { CompositeDisposable, Emitter, TextEditor, TextBuffer, Disposable, MarkerLayer, Range } from 'atom'
+import { CompositeDisposable, Emitter } from 'atom'
 import { Terminal } from 'xterm'
 import * as fit from 'xterm/lib/addons/fit/fit'
 import * as webLinks from 'xterm/lib/addons/webLinks/webLinks'
@@ -48,12 +48,12 @@ export default class InkTerminal extends PaneItem {
       'ink-terminal:find-next': ({target}) => {
         let term = getTerminal(target)
         if (term != undefined) {
-          term.searchui.findNext()
+          term.searchui.find(true)
         }},
       'ink-terminal:find-previous': ({target}) => {
         let term = getTerminal(target)
         if (term != undefined) {
-          term.searchui.findPrevious()
+          term.searchui.find(false)
         }},
       'ink-terminal:close-search': ({target}) => {
         let term = getTerminal(target)

--- a/lib/console2/console.js
+++ b/lib/console2/console.js
@@ -8,6 +8,7 @@ import { Terminal } from 'xterm'
 import * as fit from 'xterm/lib/addons/fit/fit'
 import * as webLinks from 'xterm/lib/addons/webLinks/webLinks'
 import * as winptyCompat from 'xterm/lib/addons/winptyCompat/winptyCompat'
+import * as search from 'xterm/lib/addons/search/search'
 import TerminalElement from './view'
 import PaneItem from '../util/pane-item'
 import ResizeDetector from 'element-resize-detector'
@@ -20,6 +21,7 @@ let getTerminal = el => closest(el, 'ink-terminal').getModel()
 Terminal.applyAddon(fit)
 Terminal.applyAddon(webLinks)
 Terminal.applyAddon(winptyCompat)
+Terminal.applyAddon(search)
 
 var subs
 
@@ -99,16 +101,27 @@ export default class InkTerminal extends PaneItem {
 
     this.terminal.on('title', (t) => this.setTitle(t))
 
+    var thisTerminal = this; // so = current `this`
     // Search functionality
     this.buffer = new TextBuffer("HI IT'S NATHAN");
     this._editor = new TextEditor({buffer: this.buffer})
 
-    // // Disable the more complicated find function
-    // this.buffer.findAndMarkAllInRangeSync = null;
-    // // TODO: Make this one talk to xterm!
-    // this.buffer.scanInRange = function(regex, range, iterator) {
-    //   console.log("scan");
+    // Disable the more complicated find function
+    // NOTE: originally implemented here:
+    // https://github.com/atom/superstring/blob/d84fa711487bf1127241846e84e40edb4fbc58e3/index.js#L49
+    // and here:
+    // https://github.com/atom/superstring/blob/83dc3e14c301401aafd91af865eab0253d7e911a/src/bindings/text-buffer-wrapper.cc#L466
+    this.buffer.findAndMarkAllInRangeSync = null;
+    // this.buffer.findAndMarkAllInRangeSync = function(markerIndex, nextId, exclusive, pattern, range) {
+    //   return thisTerminal._do_search_in_range(pattern,range)
     // }
+
+    // TODO: Make this one talk to xterm!
+    this.buffer.scanInRange = function(regex, range, iterator) {
+      thisTerminal._do_search_in_range(regex,range)
+      // Pretend there was a valid result so that findNext will work!
+      return new TextBuffer("aaa").scanInRange(RegExp("a"),range,iterator)
+    }
   }
 
   set class (name) {
@@ -244,44 +257,37 @@ export default class InkTerminal extends PaneItem {
   // We need to implement the interface used from find-and-replace, here:
   //   https://github.com/atom/find-and-replace/blob/71a80c0b793423e7166fd26c2f39e932b9b5cd14/lib/buffer-search.js#L35
 
-  // ------- THESE ARE THE FUNCTIONS THAT NEED TO TALK TO XTERM.JS -----------
-  // (I think)
-  scrollToCursorPosition = function(x){ }
-
-  // // Disable the more complicated find function
-  // // Returns the count of all occurences.
-  // // NOTE: originally implemented here:
-  // // https://github.com/atom/superstring/blob/83dc3e14c301401aafd91af865eab0253d7e911a/src/bindings/text-buffer-wrapper.cc#L466
-  // this.buffer.findAndMarkAllInRangeSync = null;
-  // // TODO: Make this one talk to xterm!
-  // this.buffer.scanInRange = function(regex, range, iterator) {
-  //   console.log("scan");
-  // }
-
-  //get buffer() {
-  //  return new TextBuffer("HI IT'S NATHAN");
-  //}
-  getBuffer = function(){
-    console.log("getBuffer()")
-    return this.buffer
+  // Search the Terminal through xterm.js!
+  _do_search_in_range(regex, range) {
+    this._lastRegex = regex
+    search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
   }
+
+  // Repeat the call to findNext in xterm.js
+  scrollToCursorPosition = function(_){
+    if (this._lastRegex) {
+      regex = this._lastRegex
+      search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
+    }
+  }
+
+  // ------- TextEditor search functions: -------------
+  // Implement these dummy functions, whose results are being ignored anyway
+  // since we're using xterm.js to do the searching and scrolling. We need to
+  // have them though, because find-and-replace will attempt to call them.
+  getBuffer = function(){ return this.buffer; }
   dispose = function(){ }
   onDidAddSelection = function(callback){ return new Disposable(function(){}) }
   onDidChangeSelectionRange = function(callback){ return new Disposable(function(){}) }
-  //addMarkerLayer = function(opts){ return MarkerLayer.markRange(new Range()) }
   addMarkerLayer = function(opts){ return this._editor.addMarkerLayer(opts)}
-  //decorateMarkerLayer = function(layer, params){ return null }
   decorateMarkerLayer = function(opts){ return this._editor.decorateMarkerLayer(opts)}
-  // getSelectedBufferRange = function(){ return new Range() }
   getSelectedBufferRange = function(){ return this._editor.getSelectedBufferRange()}
-  // getLastSelection = function(){ return null }
   getLastSelection = function(){ return this._editor.getLastSelection()}
 
   getFirstVisibleScreenRow = function(){ return this._editor.getFirstVisibleScreenRow()}
   getLastVisibleScreenRow = function(){ return this._editor.getLastVisibleScreenRow()}
   unfoldBufferRow = function(x){ }
   setSelectedBufferRange = function(x,y){ }
-
 }
 
 InkTerminal.registerView()

--- a/lib/console2/console.js
+++ b/lib/console2/console.js
@@ -118,11 +118,9 @@ export default class InkTerminal extends PaneItem {
 
     // TODO: Make this one talk to xterm!
     this.buffer.scanInRange = function(regex, range, iterator) {
-      let foundMatch = thisTerminal._do_search_in_range(regex,range)
-      if (foundMatch) {
-        // Pretend there was a valid result so that findNext will work!
-        return new TextBuffer("aaa").scanInRange(RegExp("a"),range,iterator)
-      }
+      thisTerminal._do_search_in_range(regex,range)
+      // Pretend there was a valid result so that findNext will work!
+      return new TextBuffer("aaa").scanInRange(RegExp("a"),range,iterator)
     }
   }
 
@@ -260,10 +258,9 @@ export default class InkTerminal extends PaneItem {
   //   https://github.com/atom/find-and-replace/blob/71a80c0b793423e7166fd26c2f39e932b9b5cd14/lib/buffer-search.js#L35
 
   // Search the Terminal through xterm.js!
-  // Returns: Whether a result was found.
   _do_search_in_range(regex, range) {
     this._lastRegex = regex
-    return search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
+    search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
   }
 
   // Repeat the call to findNext in xterm.js

--- a/lib/console2/console.js
+++ b/lib/console2/console.js
@@ -3,7 +3,7 @@
 
 import etch from 'etch'
 import { Raw } from '../util/etch.js'
-import { CompositeDisposable, Emitter } from 'atom'
+import { CompositeDisposable, Emitter, TextEditor, TextBuffer, Disposable, MarkerLayer, Range } from 'atom'
 import { Terminal } from 'xterm'
 import * as fit from 'xterm/lib/addons/fit/fit'
 import * as webLinks from 'xterm/lib/addons/webLinks/webLinks'
@@ -98,6 +98,17 @@ export default class InkTerminal extends PaneItem {
     })
 
     this.terminal.on('title', (t) => this.setTitle(t))
+
+    // Search functionality
+    this.buffer = new TextBuffer("HI IT'S NATHAN");
+    this._editor = new TextEditor({buffer: this.buffer})
+
+    // // Disable the more complicated find function
+    // this.buffer.findAndMarkAllInRangeSync = null;
+    // // TODO: Make this one talk to xterm!
+    // this.buffer.scanInRange = function(regex, range, iterator) {
+    //   console.log("scan");
+    // }
   }
 
   set class (name) {
@@ -226,6 +237,51 @@ export default class InkTerminal extends PaneItem {
   getIconName() {
     return "terminal"
   }
+
+  // ============================================
+  // ===  Implement TextEditor API for Search ===
+  // ============================================
+  // We need to implement the interface used from find-and-replace, here:
+  //   https://github.com/atom/find-and-replace/blob/71a80c0b793423e7166fd26c2f39e932b9b5cd14/lib/buffer-search.js#L35
+
+  // ------- THESE ARE THE FUNCTIONS THAT NEED TO TALK TO XTERM.JS -----------
+  // (I think)
+  scrollToCursorPosition = function(x){ }
+
+  // // Disable the more complicated find function
+  // // Returns the count of all occurences.
+  // // NOTE: originally implemented here:
+  // // https://github.com/atom/superstring/blob/83dc3e14c301401aafd91af865eab0253d7e911a/src/bindings/text-buffer-wrapper.cc#L466
+  // this.buffer.findAndMarkAllInRangeSync = null;
+  // // TODO: Make this one talk to xterm!
+  // this.buffer.scanInRange = function(regex, range, iterator) {
+  //   console.log("scan");
+  // }
+
+  //get buffer() {
+  //  return new TextBuffer("HI IT'S NATHAN");
+  //}
+  getBuffer = function(){
+    console.log("getBuffer()")
+    return this.buffer
+  }
+  dispose = function(){ }
+  onDidAddSelection = function(callback){ return new Disposable(function(){}) }
+  onDidChangeSelectionRange = function(callback){ return new Disposable(function(){}) }
+  //addMarkerLayer = function(opts){ return MarkerLayer.markRange(new Range()) }
+  addMarkerLayer = function(opts){ return this._editor.addMarkerLayer(opts)}
+  //decorateMarkerLayer = function(layer, params){ return null }
+  decorateMarkerLayer = function(opts){ return this._editor.decorateMarkerLayer(opts)}
+  // getSelectedBufferRange = function(){ return new Range() }
+  getSelectedBufferRange = function(){ return this._editor.getSelectedBufferRange()}
+  // getLastSelection = function(){ return null }
+  getLastSelection = function(){ return this._editor.getLastSelection()}
+
+  getFirstVisibleScreenRow = function(){ return this._editor.getFirstVisibleScreenRow()}
+  getLastVisibleScreenRow = function(){ return this._editor.getLastVisibleScreenRow()}
+  unfoldBufferRow = function(x){ }
+  setSelectedBufferRange = function(x,y){ }
+
 }
 
 InkTerminal.registerView()

--- a/lib/console2/console.js
+++ b/lib/console2/console.js
@@ -15,6 +15,7 @@ import ResizeDetector from 'element-resize-detector'
 import { debounce, throttle } from 'underscore-plus'
 import { closest } from './helpers'
 import { openExternal } from 'shell'
+import SearchUI from './searchui'
 
 let getTerminal = el => closest(el, 'ink-terminal').getModel()
 
@@ -38,6 +39,26 @@ export default class InkTerminal extends PaneItem {
         let term = getTerminal(target)
         if (term != undefined) {
           term.paste(process.platform != 'win32')
+        }},
+      'ink-terminal:search': ({target}) => {
+        let term = getTerminal(target)
+        if (term != undefined) {
+          term.searchui.show()
+        }},
+      'ink-terminal:find-next': ({target}) => {
+        let term = getTerminal(target)
+        if (term != undefined) {
+          term.searchui.findNext()
+        }},
+      'ink-terminal:find-previous': ({target}) => {
+        let term = getTerminal(target)
+        if (term != undefined) {
+          term.searchui.findPrevious()
+        }},
+      'ink-terminal:close-search': ({target}) => {
+        let term = getTerminal(target)
+        if (term != undefined) {
+          term.searchui.hide()
         }}
     }))
 
@@ -94,34 +115,14 @@ export default class InkTerminal extends PaneItem {
 
     this.view = new TerminalElement
 
+    this.searchui = new SearchUI(this.terminal)
+
     etch.initialize(this)
     etch.update(this).then(() => {
       this.view.initialize(this)
     })
 
     this.terminal.on('title', (t) => this.setTitle(t))
-
-    var thisTerminal = this; // so = current `this`
-    // Search functionality
-    this.buffer = new TextBuffer("HI IT'S NATHAN");
-    this._editor = new TextEditor({buffer: this.buffer})
-
-    // Disable the more complicated find function
-    // NOTE: originally implemented here:
-    // https://github.com/atom/superstring/blob/d84fa711487bf1127241846e84e40edb4fbc58e3/index.js#L49
-    // and here:
-    // https://github.com/atom/superstring/blob/83dc3e14c301401aafd91af865eab0253d7e911a/src/bindings/text-buffer-wrapper.cc#L466
-    this.buffer.findAndMarkAllInRangeSync = null;
-    // this.buffer.findAndMarkAllInRangeSync = function(markerIndex, nextId, exclusive, pattern, range) {
-    //   return thisTerminal._do_search_in_range(pattern,range)
-    // }
-
-    // TODO: Make this one talk to xterm!
-    this.buffer.scanInRange = function(regex, range, iterator) {
-      thisTerminal._do_search_in_range(regex,range)
-      // Pretend there was a valid result so that findNext will work!
-      return new TextBuffer("aaa").scanInRange(RegExp("a"),range,iterator)
-    }
   }
 
   set class (name) {
@@ -239,7 +240,7 @@ export default class InkTerminal extends PaneItem {
     bracketed && this.ty.write('\x1b[201~') // disable bracketed paste mode
   }
 
-  show (view) {
+  show () {
     this.terminal.focus()
   }
 
@@ -250,44 +251,6 @@ export default class InkTerminal extends PaneItem {
   getIconName() {
     return "terminal"
   }
-
-  // ============================================
-  // ===  Implement TextEditor API for Search ===
-  // ============================================
-  // We need to implement the interface used from find-and-replace, here:
-  //   https://github.com/atom/find-and-replace/blob/71a80c0b793423e7166fd26c2f39e932b9b5cd14/lib/buffer-search.js#L35
-
-  // Search the Terminal through xterm.js!
-  _do_search_in_range(regex, range) {
-    this._lastRegex = regex
-    search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
-  }
-
-  // Repeat the call to findNext in xterm.js
-  scrollToCursorPosition = function(_){
-    if (this._lastRegex) {
-      regex = this._lastRegex
-      search.findNext(this.terminal, regex.source, {regex: true, caseSensitive: !regex.ignoreCase})
-    }
-  }
-
-  // ------- TextEditor search functions: -------------
-  // Implement these dummy functions, whose results are being ignored anyway
-  // since we're using xterm.js to do the searching and scrolling. We need to
-  // have them though, because find-and-replace will attempt to call them.
-  getBuffer = function(){ return this.buffer; }
-  dispose = function(){ }
-  onDidAddSelection = function(callback){ return new Disposable(function(){}) }
-  onDidChangeSelectionRange = function(callback){ return new Disposable(function(){}) }
-  addMarkerLayer = function(opts){ return this._editor.addMarkerLayer(opts)}
-  decorateMarkerLayer = function(opts){ return this._editor.decorateMarkerLayer(opts)}
-  getSelectedBufferRange = function(){ return this._editor.getSelectedBufferRange()}
-  getLastSelection = function(){ return this._editor.getLastSelection()}
-
-  getFirstVisibleScreenRow = function(){ return this._editor.getFirstVisibleScreenRow()}
-  getLastVisibleScreenRow = function(){ return this._editor.getLastVisibleScreenRow()}
-  unfoldBufferRow = function(x){ }
-  setSelectedBufferRange = function(x,y){ }
 }
 
 InkTerminal.registerView()

--- a/lib/console2/console.js
+++ b/lib/console2/console.js
@@ -40,7 +40,7 @@ export default class InkTerminal extends PaneItem {
         if (term != undefined) {
           term.paste(process.platform != 'win32')
         }},
-      'ink-terminal:search': ({target}) => {
+      'ink-terminal:show-search': ({target}) => {
         let term = getTerminal(target)
         if (term != undefined) {
           term.searchui.show()
@@ -62,7 +62,7 @@ export default class InkTerminal extends PaneItem {
         }}
     }))
 
-    subs.add(atom.workspace.onDidStopChangingActivePaneItem((item) => {
+    subs.add(atom.workspace.onDidChangeActivePaneItem((item) => {
       if (item instanceof InkTerminal) {
         item.view.initialize(item)
         item.terminal.focus()

--- a/lib/console2/searchui.js
+++ b/lib/console2/searchui.js
@@ -3,7 +3,7 @@
 
 import etch from 'etch'
 import { Raw, Button, toView } from '../util/etch.js'
-import { CompositeDisposable, Emitter, TextEditor, TextBuffer, Disposable, MarkerLayer, Range } from 'atom'
+import { CompositeDisposable, Emitter, TextEditor } from 'atom'
 import { Terminal } from 'xterm'
 import * as fit from 'xterm/lib/addons/fit/fit'
 import * as webLinks from 'xterm/lib/addons/webLinks/webLinks'
@@ -26,6 +26,7 @@ export default class TerminalSearchUI {
     this.wholeWord = false
 
     this.initialized = false
+    this.errorMessage = ''
 
     etch.initialize(this)
   }
@@ -47,23 +48,47 @@ export default class TerminalSearchUI {
     this.refs.toggleWhole.element.classList.toggle('selected')
   }
 
-  findNext () {
-    let found = this.terminal.findNext(this.editor.getText(), {
-      regex: this.useRegex,
-      wholeWord: this.wholeWord,
-      caseSensitive: this.matchCase,
-      incremental: true
-    })
-
-    if (!found) this.blinkRed()
+  toggleError (show) {
+    let el = this.refs.errorMessage
+    show ? el.classList.remove('hidden') : el.classList.add('hidden')
+    etch.update(this)
   }
 
-  findPrevious () {
-    let found = this.terminal.findPrevious(this.editor.getText(), {
-      regex: this.useRegex,
-      wholeWord: this.wholeWord,
-      caseSensitive: this.matchCase
-    })
+  find (next) {
+
+    let text = this.editor.getText()
+    if (this.useRegex) {
+      let msg = null
+      try {
+        new RegExp(text)
+      } catch (err) {
+        msg = err.message
+      }
+
+      if (msg !== null) {
+        this.errorMessage = msg
+        this.toggleError(true)
+        this.blinkRed()
+        return false
+      }
+    }
+    this.toggleError(false)
+
+    let found
+    if (next) {
+      found = this.terminal.findNext(text, {
+        regex: this.useRegex,
+        wholeWord: this.wholeWord,
+        caseSensitive: this.matchCase,
+        incremental: true
+      })
+    } else {
+      found = this.terminal.findPrevious(text, {
+        regex: this.useRegex,
+        wholeWord: this.wholeWord,
+        caseSensitive: this.matchCase
+      })
+    }
 
     if (!found) this.blinkRed()
   }
@@ -74,46 +99,52 @@ export default class TerminalSearchUI {
   }
 
   render () {
-    return <div className='ink terminal search hidden'>
-      <span className='searchinput'>{ toView(this.editor.element) }</span>
-      <div className='btn-group searchoptions'>
-        <Button className='btn-sm'
-                ref='toggleRegex'
-                alt='Use Regex'
-                onclick={() => this.toggleRegex()}>
-        .*
-        </Button>
-        <Button className='btn-sm'
-                ref='toggleCase'
-                alt='Match Case'
-                onclick={() => this.toggleCase()}>
-        Aa
-        </Button>
-        <Button className='btn-sm'
-                ref='toggleWhole'
-                alt='Whole Word'
-                onclick={() => this.toggleWhole()}>
-        \b
-        </Button>
+    return <div className='ink search hidden'>
+      <div className='inputs'>
+        <span className='searchinput'>{ toView(this.editor.element) }</span>
+        <div className='btn-group searchoptions'>
+          <Button className='btn-sm'
+                  ref='toggleRegex'
+                  alt='Use Regex'
+                  onclick={() => this.toggleRegex()}>
+          .*
+          </Button>
+          <Button className='btn-sm'
+                  ref='toggleCase'
+                  alt='Match Case'
+                  onclick={() => this.toggleCase()}>
+          Aa
+          </Button>
+          <Button className='btn-sm'
+                  ref='toggleWhole'
+                  alt='Whole Word'
+                  onclick={() => this.toggleWhole()}>
+          \b
+          </Button>
+        </div>
+        <div className='btn-group nextprev'>
+          <Button className='btn-sm'
+                  alt='Find Previous'
+                  icon='chevron-left'
+                  onclick={() => this.find(false)}>
+          </Button>
+          <Button className='btn-sm'
+                  alt='Find Next'
+                  icon='chevron-right'
+                  onclick={() => this.find(true)}>
+          </Button>
+        </div>
+        <div className='btn-group closebutton'>
+          <Button className='btn-sm'
+                  alt='Close'
+                  icon='x'
+                  onclick={() => this.hide()}>
+          </Button>
+        </div>
       </div>
-      <div className='btn-group nextprev'>
-        <Button className='btn-sm'
-                alt='Find Previous'
-                icon='chevron-left'
-                onclick={() => this.findPrevious()}>
-        </Button>
-        <Button className='btn-sm'
-                alt='Find Next'
-                icon='chevron-right'
-                onclick={() => this.findNext()}>
-        </Button>
-      </div>
-      <div className='btn-group closebutton'>
-        <Button className='btn-sm'
-                alt='Close'
-                icon='x'
-                onclick={() => this.hide()}>
-        </Button>
+      <div className='errormessage hidden'
+           ref='errorMessage'>
+        {this.errorMessage}
       </div>
     </div>
   }

--- a/lib/console2/searchui.js
+++ b/lib/console2/searchui.js
@@ -1,0 +1,137 @@
+'use babel'
+/** @jsx etch.dom */
+
+import etch from 'etch'
+import { Raw, Button, toView } from '../util/etch.js'
+import { CompositeDisposable, Emitter, TextEditor, TextBuffer, Disposable, MarkerLayer, Range } from 'atom'
+import { Terminal } from 'xterm'
+import * as fit from 'xterm/lib/addons/fit/fit'
+import * as webLinks from 'xterm/lib/addons/webLinks/webLinks'
+import * as winptyCompat from 'xterm/lib/addons/winptyCompat/winptyCompat'
+import * as search from 'xterm/lib/addons/search/search'
+import TerminalElement from './view'
+import PaneItem from '../util/pane-item'
+import ResizeDetector from 'element-resize-detector'
+import { debounce, throttle } from 'underscore-plus'
+import { closest } from './helpers'
+import { openExternal } from 'shell'
+
+export default class TerminalSearchUI {
+  constructor (terminal) {
+    this.terminal = terminal
+    this.editor = new TextEditor( {mini: true, placeholderText: 'Find in Terminal'} )
+
+    this.useRegex = false
+    this.matchCase = false
+    this.wholeWord = false
+
+    this.initialized = false
+
+    etch.initialize(this)
+  }
+
+  update () {}
+
+  toggleRegex () {
+    this.useRegex = !this.useRegex
+    this.refs.toggleRegex.element.classList.toggle('selected')
+  }
+
+  toggleCase () {
+    this.matchCase = !this.matchCase
+    this.refs.toggleCase.element.classList.toggle('selected')
+  }
+
+  toggleWhole () {
+    this.wholeWord = !this.wholeWord
+    this.refs.toggleWhole.element.classList.toggle('selected')
+  }
+
+  findNext () {
+    let found = this.terminal.findNext(this.editor.getText(), {
+      regex: this.useRegex,
+      wholeWord: this.wholeWord,
+      caseSensitive: this.matchCase,
+      incremental: true
+    })
+
+    if (!found) this.blinkRed()
+  }
+
+  findPrevious () {
+    let found = this.terminal.findPrevious(this.editor.getText(), {
+      regex: this.useRegex,
+      wholeWord: this.wholeWord,
+      caseSensitive: this.matchCase
+    })
+
+    if (!found) this.blinkRed()
+  }
+
+  blinkRed () {
+    this.element.classList.add('nothingfound')
+    setTimeout(() => this.element.classList.remove('nothingfound'), 200)
+  }
+
+  render () {
+    return <div className='ink terminal search hidden'>
+      <span className='searchinput'>{ toView(this.editor.element) }</span>
+      <div className='btn-group searchoptions'>
+        <Button className='btn-sm'
+                ref='toggleRegex'
+                alt='Use Regex'
+                onclick={() => this.toggleRegex()}>
+        .*
+        </Button>
+        <Button className='btn-sm'
+                ref='toggleCase'
+                alt='Match Case'
+                onclick={() => this.toggleCase()}>
+        Aa
+        </Button>
+        <Button className='btn-sm'
+                ref='toggleWhole'
+                alt='Whole Word'
+                onclick={() => this.toggleWhole()}>
+        \b
+        </Button>
+      </div>
+      <div className='btn-group nextprev'>
+        <Button className='btn-sm'
+                alt='Find Previous'
+                icon='chevron-left'
+                onclick={() => this.findPrevious()}>
+        </Button>
+        <Button className='btn-sm'
+                alt='Find Next'
+                icon='chevron-right'
+                onclick={() => this.findNext()}>
+        </Button>
+      </div>
+      <div className='btn-group closebutton'>
+        <Button className='btn-sm'
+                alt='Close'
+                icon='x'
+                onclick={() => this.hide()}>
+        </Button>
+      </div>
+    </div>
+  }
+
+  attach (element) {
+    if (!this.initialized) {
+      element.appendChild(this.element)
+      this.initialized = true
+    }
+  }
+
+  show () {
+    this.element.classList.remove('hidden')
+    this.editor.element.focus()
+  }
+
+  hide () {
+    this.element.classList.add('hidden')
+    this.terminal.focus()
+  }
+}

--- a/lib/console2/searchui.js
+++ b/lib/console2/searchui.js
@@ -80,7 +80,7 @@ export default class TerminalSearchUI {
         regex: this.useRegex,
         wholeWord: this.wholeWord,
         caseSensitive: this.matchCase,
-        incremental: true
+        incremental: false
       })
     } else {
       found = this.terminal.findPrevious(text, {

--- a/lib/console2/view.js
+++ b/lib/console2/view.js
@@ -48,6 +48,8 @@ class TerminalElement extends HTMLElement {
     this.themeTerminal()
     this.initMouseHandling()
 
+    this.model.searchui.attach(this)
+
     return this
   }
 

--- a/lib/util/etch.js
+++ b/lib/util/etch.js
@@ -135,8 +135,9 @@ export class Badge extends Etch {
 export class Button extends Etch {
   render() {
     let iconclass = this.props.icon ? ` icon icon-${this.props.icon}` : '';
+    let classname = this.props.className || ''
     return <Tip alt={this.props.alt}>
-      <button className={'btn' + iconclass} disabled={this.props.disabled} onclick={this.props.onclick}>{
+      <button className={'btn' + iconclass + ' ' + classname} disabled={this.props.disabled} onclick={this.props.onclick}>{
         this.children
       }</button>
     </Tip>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -677,9 +677,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xterm": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.9.1.tgz",
-      "integrity": "sha512-5AZlhP0jvH/Sskx1UvvNFMqDRHVFqapl59rjV3RRpTJmveoharJplxPfzSThk85I4+AZo2xvD0X0nh0AAzkeZQ=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.10.0.tgz",
+      "integrity": "sha512-ZA55MObCk8xKHG0TjZpStCJn6oIkPkW24ZtagZpUdol9kHYJ36imPsesZdVXsyxQd1le4RPpSpDU9O/rqq/yCA=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "katex": "^0.9.0",
     "fs-extra": "^5.0.0",
     "replace-in-file": "^3.0.0",
-    "xterm": "3.9.1",
+    "xterm": "3.10.0",
     "chroma-js": "^1.3.7"
   },
   "scripts": {

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -1,5 +1,5 @@
 @import "syntax-variables";
-
+@import "ui-variables";
 
 ink-terminal, .ink-terminal {
   height: 100%;
@@ -12,6 +12,35 @@ ink-terminal, .ink-terminal {
 
     .xterm-viewport {
       background-color: @syntax-background-color !important;
+    }
+  }
+
+  .search {
+    position: absolute;
+    display: flex;
+    flex-direction: row;
+    top: 0.5em;
+    right: 1em;
+    background-color: @app-background-color;
+    width: 30em;
+    padding: 0.5em;
+    z-index: 5;
+    transition: border-color 0.2s;
+    border: 2px @base-border-color solid;
+    border-radius: 2px;
+
+    >* {
+      padding-left: 0.5em;
+      margin: auto;
+    }
+
+    .searchinput {
+      flex: 1;
+      padding-left: 0;
+    }
+
+    &.nothingfound {
+      border-color: @background-color-error;
     }
   }
 }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -17,8 +17,6 @@ ink-terminal, .ink-terminal {
 
   .search {
     position: absolute;
-    display: flex;
-    flex-direction: row;
     top: 0.5em;
     right: 1em;
     background-color: @app-background-color;
@@ -29,14 +27,24 @@ ink-terminal, .ink-terminal {
     border: 2px @base-border-color solid;
     border-radius: 2px;
 
-    >* {
-      padding-left: 0.5em;
-      margin: auto;
+    .inputs {
+      flex-direction: row;
+      display: flex;
+
+      >* {
+        padding-left: 0.5em;
+        margin: auto;
+      }
+
+      .searchinput {
+        flex: 1;
+        padding-left: 0;
+      }
     }
 
-    .searchinput {
-      flex: 1;
-      padding-left: 0;
+    .errormessage {
+      color: @text-color-error;
+      margin-top: 0.5em;
     }
 
     &.nothingfound {


### PR DESCRIPTION
Integrates the Julia Console with Atom's built-in `find-and-replace` plugin!

Still a work in progress. Some remaining features that are probably necessary:

- [x] Show the correct number of matches (currently always shows `1` -- which is arbitrary)
- [x] show "No results found" if zero matches.
- [x] Allow find-previous as well as find-next
- [x] Cycling through multiple results on the same line

Finished features:

- [x] search through the whole Console output
- [x] enable/disable Regex matching
- [x] enable/disable Case-sensitive search

Some of those missing features will get easier after the refactoring planned here: https://github.com/xtermjs/xterm.js/issues/1833

But still, it's not bad as-is!! It might be already at a stage where it's worth merging after we clean up the code / pare it down to just what's needed, and add unit tests...

Fixes https://github.com/JunoLab/Juno.jl/issues/212.