### PR TITLE
Focus searchEd when opening documentation/workspace pane

### DIFF
--- a/lib/docs/docpane.js
+++ b/lib/docs/docpane.js
@@ -41,9 +41,11 @@ export default class DocPane extends PaneItem {
     this.element.setAttribute('tabindex', -1)
   }
 
-  async open(opts) {
-    await super.open(opts)
-    this.searchEd.getElement().focus()
+  open(opts) {
+    super.open(opts)
+      .then(docPane => {
+        docPane.searchEd.getElement().focus()
+      })
   }
 
   _search (query = this.searchEd.getText(), mod = this.modEd.getText(),

--- a/lib/docs/docpane.js
+++ b/lib/docs/docpane.js
@@ -41,6 +41,11 @@ export default class DocPane extends PaneItem {
     this.element.setAttribute('tabindex', -1)
   }
 
+  async open(opts) {
+    await super.open(opts)
+    this.searchEd.getElement().focus()
+  }
+
   _search (query = this.searchEd.getText(), mod = this.modEd.getText(),
            eo = this.exportedOnly, ap = this.allPackages, np = this.namesOnly) {
     this.setContent('loading')

--- a/lib/workspace/workspace.js
+++ b/lib/workspace/workspace.js
@@ -36,9 +36,11 @@ export default class Workspace extends PaneItem {
     this.element.classList.add('ink-workspace')
   }
 
-  async open(opts) {
-    await super.open(opts)
-    this.searchEd.getElement().focus()
+  open(opts) {
+    super.open(opts)
+      .then(workspace => {
+        workspace.searchEd.getElement().focus()
+      })
   }
 
   setItems(items) {

--- a/lib/workspace/workspace.js
+++ b/lib/workspace/workspace.js
@@ -36,6 +36,11 @@ export default class Workspace extends PaneItem {
     this.element.classList.add('ink-workspace')
   }
 
+  async open(opts) {
+    await super.open(opts)
+    this.searchEd.getElement().focus()
+  }
+
   setItems(items) {
     this.items = items
     this.filterItems(this.searchEd.getText())


### PR DESCRIPTION
Currently `julia-client:open-documentation-browser` and `julia-client:open-workspace` opens those panes and move the focus to them from a previously focused item.
This patch would make those commands more useful by making the attached mini editors focused instead of the panes themselves.

As for the documentation pane, `julia-client:show-documentation` can also open the pane, but I think the current behaviour (keeping focus on an previous editor) is better with this command, thus I didn't change the method.
