### PR TITLE
Correct JSX styles in doc/workspace pane

### DIFF
--- a/lib/docs/docpane.js
+++ b/lib/docs/docpane.js
@@ -7,7 +7,8 @@ import { TextEditor, CompositeDisposable } from 'atom'
 import PaneItem from '../util/pane-item'
 import { toView, Toolbar, Button, Icon, makeicon, Etch } from '../util/etch'
 
-let codeFontFamily, codeFontSize
+let codeFontFamily = atom.config.get('editor.fontFamily')
+let codeFontSize = atom.config.get('editor.fontSize') + 'px'
 
 export default class DocPane extends PaneItem {
   constructor () {
@@ -31,11 +32,9 @@ export default class DocPane extends PaneItem {
     this.subs.add(atom.config.observe('editor.fontFamily', v => {
       codeFontFamily = v
     }))
-
     this.subs.add(atom.config.observe('editor.fontSize', v => {
       codeFontSize = v + 'px'
     }))
-
 
     etch.initialize(this)
     this.element.setAttribute('tabindex', -1)
@@ -148,7 +147,7 @@ export default class DocPane extends PaneItem {
   update () {}
 
   render () {
-    let codeStyle = `font-family: ${codeFontFamily};`
+    const codeStyle = { fontFamily: codeFontFamily, fontSize: codeFontSize }
     return <div className="ink docpane" style={codeStyle}>
       {this.headerView()}
       {this.contentView()}

--- a/lib/workspace/workspace.js
+++ b/lib/workspace/workspace.js
@@ -4,8 +4,11 @@
 import etch from "etch"
 import PaneItem from '../util/pane-item'
 import { toView, Button } from '../util/etch'
-import { TextEditor } from 'atom'
+import { TextEditor, CompositeDisposable } from 'atom'
 import * as fuzzaldrinPlus from 'fuzzaldrin-plus'
+
+let codeFontFamily = atom.config.get('editor.fontFamily')
+let codeFontSize = atom.config.get('editor.fontSize') + 'px'
 
 function makeicon(type) {
   if (!type) return 'c';
@@ -30,6 +33,14 @@ export default class Workspace extends PaneItem {
     this.filteredItems = []
 
     this.searchEd.onDidStopChanging(() => this.filterItems(this.searchEd.getText()))
+
+    this.subs = new CompositeDisposable()
+    this.subs.add(atom.config.observe('editor.fontFamily', v => {
+      codeFontFamily = v
+    }))
+    this.subs.add(atom.config.observe('editor.fontSize', v => {
+      codeFontSize = v + 'px'
+    }))
 
     etch.initialize(this)
     this.element.setAttribute('tabindex', -1)
@@ -76,8 +87,8 @@ export default class Workspace extends PaneItem {
   update(props, children) {}
 
   render(props, children) {
-    let i = 0
-    return <div>
+    const style = { fontFamily: codeFontFamily, fontSize: codeFontSize }
+    return <div style={style}>
       <div className="workspace-header">
         <span className="header-main">
           <span className="search-editor">{toView(this.searchEd.element)}</span>
@@ -108,6 +119,6 @@ export default class Workspace extends PaneItem {
     </div>
   }
 
-};
+}
 
 Workspace.registerView();


### PR DESCRIPTION
While working on #200, I found JSX styling for dynamic font-changing in [docpane.js](lib/docs/docpane.js) is kinda broken.
I fixed it and also added the same styling to [workspace.js](lib/workspace/workspace.js).

Now both panes correctly reflects the font changes:
![image](https://user-images.githubusercontent.com/40514306/58348250-1e022b00-7e9b-11e9-862b-985e54c09f91.png)
