### PR TITLE
fix docpane/workspace styling

### DIFF
--- a/lib/docs/docpane.js
+++ b/lib/docs/docpane.js
@@ -7,9 +7,6 @@ import { TextEditor, CompositeDisposable } from 'atom'
 import PaneItem from '../util/pane-item'
 import { toView, Toolbar, Button, Icon, makeicon, Etch } from '../util/etch'
 
-let codeFontFamily = atom.config.get('editor.fontFamily')
-let codeFontSize = atom.config.get('editor.fontSize') + 'px'
-
 export default class DocPane extends PaneItem {
   constructor () {
     super()
@@ -27,13 +24,6 @@ export default class DocPane extends PaneItem {
     this.subs = new CompositeDisposable()
     this.subs.add(atom.commands.add('.docpane .header .editor', {
       'docpane:search': () => this._search()
-    }))
-
-    this.subs.add(atom.config.observe('editor.fontFamily', v => {
-      codeFontFamily = v
-    }))
-    this.subs.add(atom.config.observe('editor.fontSize', v => {
-      codeFontSize = v + 'px'
     }))
 
     etch.initialize(this)
@@ -154,8 +144,7 @@ export default class DocPane extends PaneItem {
   update () {}
 
   render () {
-    const codeStyle = { fontFamily: codeFontFamily, fontSize: codeFontSize }
-    return <div className="ink docpane" style={codeStyle}>
+    return <div className="ink docpane">
       {this.headerView()}
       {this.contentView()}
     </div>
@@ -189,7 +178,7 @@ class DocItem extends Etch {
                <span className="module" onclick={this.props.item.onClickModule}>{this.props.item.mod}</span>
              </div>
              <div ref='itemBody' className="item-body collapsed">
-               <span className="docs">{toView(this.props.item.html)}</span>
+               <div className="docs">{toView(this.props.item.html)}</div>
                <span className='expander' onclick={() => this.expand()}>...</span>
              </div>
            </div>

--- a/lib/workspace/workspace.js
+++ b/lib/workspace/workspace.js
@@ -7,9 +7,6 @@ import { toView, Button } from '../util/etch'
 import { TextEditor, CompositeDisposable } from 'atom'
 import * as fuzzaldrinPlus from 'fuzzaldrin-plus'
 
-let codeFontFamily = atom.config.get('editor.fontFamily')
-let codeFontSize = atom.config.get('editor.fontSize') + 'px'
-
 function makeicon(type) {
   if (!type) return 'c';
   else if (type.startsWith('icon-')) return <span className={`icon ${type}`}/>;
@@ -35,12 +32,6 @@ export default class Workspace extends PaneItem {
     this.searchEd.onDidStopChanging(() => this.filterItems(this.searchEd.getText()))
 
     this.subs = new CompositeDisposable()
-    this.subs.add(atom.config.observe('editor.fontFamily', v => {
-      codeFontFamily = v
-    }))
-    this.subs.add(atom.config.observe('editor.fontSize', v => {
-      codeFontSize = v + 'px'
-    }))
 
     etch.initialize(this)
     this.element.setAttribute('tabindex', -1)
@@ -94,8 +85,7 @@ export default class Workspace extends PaneItem {
   update(props, children) {}
 
   render(props, children) {
-    const style = { fontFamily: codeFontFamily, fontSize: codeFontSize }
-    return <div style={style}>
+    return <div>
       <div className="workspace-header">
         <span className="header-main">
           <span className="search-editor">{toView(this.searchEd.element)}</span>

--- a/styles/docpane.less
+++ b/styles/docpane.less
@@ -5,6 +5,7 @@
 .docpane {
   background: @syntax-background-color;
   color: @syntax-text-color;
+  font-family: var(--editor-font-family);
 
   display: flex;
   flex-direction: column;
@@ -53,7 +54,8 @@
 
     .item {
       padding: 5px;
-      border-bottom: @base-border-color 1px solid;
+      border-top: @base-border-color 1px solid;
+      margin-bottom: -1.3em;
 
       .typ .icon {
         .icon-mixin;
@@ -68,7 +70,6 @@
           position: relative;
           line-height: 1.2em;
           max-height: 8em;
-          // padding-bottom: 0;
 
           .expander {
             position: absolute;
@@ -92,6 +93,10 @@
             margin-top: -1.5em;
             background: @syntax-background-color;
           }
+        }
+
+        .docs {
+          padding-bottom: 1.5em;
         }
 
         .expander {

--- a/styles/workspace.less
+++ b/styles/workspace.less
@@ -7,7 +7,7 @@
   cursor: default;
   overflow: auto;
   white-space: pre;
-  font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  font-family: var(--editor-font-family);
 
   * {
     vertical-align: top;


### PR DESCRIPTION
This reverts some of the changes from https://github.com/JunoLab/atom-ink/pull/202 because the font size in those pane items should be the UI font size, not the editor font size. 