### PR TITLE
Add optional argument for `goto` function to enable pending

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
-    - libgconf2-4 # @TODO: Remove once Atom v1.39 comes to be stable
 
 notifications:
   email: false

--- a/lib/util/gotodef.coffee
+++ b/lib/util/gotodef.coffee
@@ -92,4 +92,6 @@ class GotoView extends SelectListView
     @hide()
 
   @openItem: (item) ->
-    open(item.file, item.line)
+    open(item.file, item.line, {
+      pending: true
+    })

--- a/lib/util/gotodef.coffee
+++ b/lib/util/gotodef.coffee
@@ -22,8 +22,9 @@
 
 
 module.exports =
-goto: (symbolTableOrPromise) ->
+goto: (symbolTableOrPromise, opts) ->
   @view ?= new GotoView()
+  @view.pending = opts?.pending
 
   # this allows either a promise or a symbolTable as the input
   promise = Promise.resolve symbolTableOrPromise
@@ -33,7 +34,7 @@ goto: (symbolTableOrPromise) ->
       @view.setError symbolTable.items
       @view.show()
     else if symbolTable.items.length == 1
-      GotoView.openItem symbolTable.items[0]
+      @view.openItem symbolTable.items[0]
     else if symbolTable.items.length > 1
       @view.setItems symbolTable.items
       @view.show()
@@ -84,14 +85,14 @@ class GotoView extends SelectListView
 
   # Jump to `item.file` at line `item.line`, when an item was selected.
   confirmed: (item) ->
-    GotoView.openItem item
+    @openItem item
     @hide()
 
   # Return to previously focused element when the modal panel is cancelled.
   cancelled: ->
     @hide()
 
-  @openItem: (item) ->
+  openItem: (item) ->
     open(item.file, item.line, {
-      pending: true
+      pending: @pending
     })

--- a/lib/util/opener.js
+++ b/lib/util/opener.js
@@ -29,20 +29,20 @@ class EditorLocation {
 }
 
 export function open (pathOrId, line, {pending = false, existingOnly = true, remote = false} = {}) {
-  let id = getUntitledId(pathOrId)
+  const id = getUntitledId(pathOrId)
 
   let oldLocation = undefined
   const activeItem = atom.workspace.getActivePaneItem()
   if (activeItem instanceof TextEditor) {
-    let path = activeItem.getPath() || 'untitled-' + activeItem.buffer.getId()
-    let line = activeItem.getCursorBufferPosition().row
+    const path = activeItem.getPath() || 'untitled-' + activeItem.buffer.getId()
+    const line = activeItem.getCursorBufferPosition().row
     oldLocation = new EditorLocation(path, line, {pending, existingOnly, remote})
   }
 
   if (id) {
     focusEditorPane()
     return openEditorById(id, line).then((ed) => {
-      let edloc = new EditorLocation(pathOrId, line, {pending, existingOnly, remote})
+      const edloc = new EditorLocation(pathOrId, line, {pending, existingOnly, remote})
       emitter.emit('didOpen', {
         oldLocation: oldLocation,
         newLocation: edloc
@@ -51,9 +51,9 @@ export function open (pathOrId, line, {pending = false, existingOnly = true, rem
   } else if (allowremote && remoteFileOpener) {
     focusEditorPane()
     return new Promise((resolve, reject) => {
-      let disposable = atom.workspace.observeActiveTextEditor(ed => {
+      const disposable = atom.workspace.observeActiveTextEditor(ed => {
         if (editorMatchesFile(ed, pathOrId)) {
-          let edloc = new EditorLocation(pathOrId, line, {pending, existingOnly, remote})
+          const edloc = new EditorLocation(pathOrId, line, {pending, existingOnly, remote})
           emitter.emit('didOpen', {
             oldLocation: oldLocation,
             newLocation: edloc
@@ -72,7 +72,7 @@ export function open (pathOrId, line, {pending = false, existingOnly = true, rem
   } else if (!existingOnly || existsSync(pathOrId)) {
     focusEditorPane()
     return atom.workspace.open(pathOrId, {initialLine: line, searchAllPanes: true, pending}).then((ed) => {
-      let edloc = new EditorLocation(pathOrId, line, {pending, existingOnly, remote})
+      const edloc = new EditorLocation(pathOrId, line, {pending, existingOnly, remote})
       emitter.emit('didOpen', {
         oldLocation: oldLocation,
         newLocation: edloc
@@ -91,7 +91,7 @@ export function editorMatchesFile (ed, pathOrId) {
   if (!ed || !pathOrId) {
     return false
   }
-  let id = getUntitledId(pathOrId)
+  const id = getUntitledId(pathOrId)
   let ep = ed.getPath()
   if (id) {
     return ed.getBuffer().id == id


### PR DESCRIPTION
This is just a suggestion, please feel free to close this if you guys don't like it.

IMO within julia-client's goto feature, pending open seems to be better to keep opened editors clean, and the closed editors can be easily restored by `Julia-Client: Return-From-Goto`.

***

### Update

I approach this by making `opts` optional arguments to `goto` function so that the consumer package (atom-julia-client) can pass the option for pending opening.

The corresponding PR on atom-julia-client side is: https://github.com/JunoLab/atom-julia-client/pull/579