### PR TITLE
Sensible open

### DIFF
--- a/lib/console2/view.js
+++ b/lib/console2/view.js
@@ -129,14 +129,14 @@ class TerminalElement extends HTMLElement {
   }
 }
 
+function hex(x) {
+  return ("0" + parseInt(x).toString(16)).slice(-2);
+}
 function rgb2hex (rgb) {
   if (rgb.search("rgb") == -1) {
     return rgb
   } else {
     rgb = rgb.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+))?\)$/)
-    function hex(x) {
-      return ("0" + parseInt(x).toString(16)).slice(-2);
-    }
     return "#" + hex(rgb[1]) + hex(rgb[2]) + hex(rgb[3]);
   }
 }

--- a/lib/util/pane-item.js
+++ b/lib/util/pane-item.js
@@ -192,8 +192,12 @@ export default class PaneItem {
   }
 
   static focusEditorPane() {
-    let cur = atom.workspace.getActivePaneItem()
-    if (cur instanceof TextEditor) return
+    const editor = atom.workspace.getActiveTextEditor()
+    if (editor) {
+      const pane = atom.workspace.paneForItem(editor)
+      pane.focus()
+      return
+    }
     for (const pane of atom.workspace.getPanes()) {
       if (pane.getActiveItem() instanceof TextEditor) {
         pane.focus()

--- a/lib/util/pane-item.js
+++ b/lib/util/pane-item.js
@@ -2,9 +2,9 @@
 
 import { CompositeDisposable, TextEditor, Emitter } from 'atom'
 
-let subs = new CompositeDisposable
-let panes = new Set
-let registered = {}
+let subs = new CompositeDisposable()
+const panes = new Set
+const registered = {}
 
 function ensurePaneVisible(pane) {
   if (!pane) return
@@ -18,7 +18,7 @@ function ensurePaneVisible(pane) {
 
 function ensurePaneContainerVisible(pane) {
   if (pane.getActiveItem) {
-    let container = atom.workspace.paneContainerForItem(pane.getActiveItem())
+    const container = atom.workspace.paneContainerForItem(pane.getActiveItem())
     if (container.isVisible && !container.isVisible()) container.show()
   }
 }
@@ -72,9 +72,9 @@ export default class PaneItem {
     }))
 
     subs.add(atom.workspace.addOpener(uri => {
-      let m
-      if (m = uri.match(new RegExp(`atom://ink-${this.name.toLowerCase()}/(.+)`))) {
-        let [_, id] = m
+      const match = uri.match(new RegExp(`atom://ink-${this.name.toLowerCase()}/(.+)`))
+      if (match) {
+        const id = match[1]
         return this.fromId(id)
       }
     }))
@@ -82,11 +82,11 @@ export default class PaneItem {
 
   static fromId(id, ...args) {
     const constructorName = this.name.toLowerCase()
-    let pane
     if (!registered[constructorName]) {
       registered[constructorName] = {}
     }
-    if (pane = registered[constructorName][id]) {
+    let pane = registered[constructorName][id]
+    if (pane) {
       return pane
     } else {
       pane = registered[constructorName][id] = new this(...args)
@@ -125,8 +125,8 @@ export default class PaneItem {
   }
 
   activate() {
-    let pane
-    if (pane = this.currentPane()) {
+    const pane = this.currentPane()
+    if (pane) {
       pane.activate()
       pane.setActiveItem(this)
       ensurePaneVisible(pane)


### PR DESCRIPTION
## purpose

fixes the behaviour of `focusEditorPane`:
- within the current implementation, if the active pane is not an `TextEditor`, then the activated pane would be kinda random depending on the order of `getPanes`
- with this fix, the activated pane gonna be a previously active pane, even if we have such a silly pane state like below:
![image](https://user-images.githubusercontent.com/40514306/62846832-fdb17200-bd0d-11e9-8b9c-b5669557547d.png)
(the current implementation would open `essential.jl` in the abovemost pane)

## misc

as always, I included some boring eslint fixes.