### PR TITLE
fix style of outline

### DIFF
--- a/styles/outline.less
+++ b/styles/outline.less
@@ -59,10 +59,12 @@
 
         &.icon {
           .icon-mixin;
+          display: inline-block;
         }
 
         &.name {
           padding-left: 0.5em;
+          display: inline-block;
         }
       }
     }


### PR DESCRIPTION
| before | after |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/40514306/64180880-800dfb80-cea0-11e9-8958-a1b3954b42ec.png)  | ![image](https://user-images.githubusercontent.com/40514306/64180834-6a98d180-cea0-11e9-9843-f7b6034f0e26.png) |

(when `name` is not so long enough to occupy the pane width)