### PR TITLE
refactor debugger pane:

### DIFF
--- a/lib/debugger/debugger-pane.js
+++ b/lib/debugger/debugger-pane.js
@@ -13,13 +13,14 @@ import { DebuggerToolbar } from './toolbar'
 // pane for side-to-side view of compiled code and source code
 export default class DebuggerPane extends PaneItem {
   name = 'DebuggerPane'
+  compileModeTip = 'Breakpoints not in the current calling scope don\'t work in Compiled Mode'
 
   static activate () {
-    subs = new CompositeDisposable()
+    DebuggerPane.subs = new CompositeDisposable()
   }
 
   static deactivate () {
-    subs.dispose()
+    DebuggerPane.subs.dispose()
   }
 
   constructor (stepper, breakpointManager, buttons=[]) {
@@ -34,6 +35,7 @@ export default class DebuggerPane extends PaneItem {
 
     this.stepper.onStep(arg => this.updateStepper(arg))
     this.breakpointManager.onUpdate(arg => this.updateBreakpoints(arg))
+    this.toggleCompiled = () => this.breakpointManager.toggleCompiled()
 
     this.stack = []
     this.activeLevel = undefined
@@ -103,72 +105,73 @@ export default class DebuggerPane extends PaneItem {
 
   // stepping
   toolbarView () {
-    const toggleCompiled = () => this.breakpointManager.toggleCompiled()
+    const expressionHidden = !this.info.text
 
     return  <div className="item toolbar">
       <div className="inner-toolbar">
         {toView(this.toolbar.view)}
+        <Tip alt={this.compileModeTip}>
+          <div className="flex-table-container">
+            <div class="flex-table row">
+              <div class="flex-row first">
+                <input
+                  class='input-checkbox'
+                  type='checkbox'
+                  onclick={this.toggleCompiled}
+                  checked={this.breakpointManager.compiledMode}>
+                </input>
+              </div>
+              <div class="flex-row second">
+                <span>Compiled Mode</span>
+              </div>
+            </div>
+          </div>
+        </Tip>
       </div>
 
-      <div className="next-expression">
-        <span
-          className="icon icon-chevron-right"
-        >
+      <div className={"next-expression " + (expressionHidden ? "hidden" : "")}>
+        <span className="icon icon-chevron-right"></span>
+        <span className="code">
+          {toView(views.render(views.tags.span('stepper-label', this.info.text)))}
         </span>
-        <span className="code">{toView(views.render(views.tags.span('stepper-label', this.info.text)))}</span>
-      </div>
-
-      <div className="flex-table-container">
-        <div class="flex-table row">
-          <div class="flex-row first">
-            <input
-              class='input-checkbox'
-              type='checkbox'
-              onclick={toggleCompiled}
-              checked={this.breakpointManager.compiledMode}>
-            </input>
-          </div>
-          <div class="flex-row second">
-            <Tip alt="Breakpoints don't work in Compiled Mode">
-              <span>Run in Compiled Mode</span>
-            </Tip>
-          </div>
-          <div class="flex-row third"></div>
-        </div>
       </div>
     </div>
   }
 
-  // callstack + current code
+  // current code + callstack
   currentlyAtView () {
     const setLevel = (level) => {
       this.breakpointManager.setLevel(level)
     }
 
-    const editorHidden = !(this.info.code && this.info.code.length > 0)
-    return  <div className="item">
-      <div className={"debugger-editor " + (editorHidden ? "hidden" : "")}>
+    const codeHidden = !(this.info.code && this.info.code.length > 0)
+    const callstackHidden = this.stack.length === 0
+    return <div className="item">
+      <div className={"debugger-editor " + (codeHidden ? "hidden" : "")}>
+        <div className="header">
+          <h4>Current code</h4>
+        </div>
         {toView(this.currentlyAtEditor.element)}
       </div>
-      <div className="header">
-        <h4>Callstack</h4>
-      </div>
-      <div className="ink-callstack-container">
+      <div className={"ink-callstack-container " + (callstackHidden ? "hidden" : "")}>
+        <div className="header">
+          <h4>Callstack</h4>
+        </div>
         <div className="flex-table-container">
           {this.stack.map(item => {
              return <div className={`flex-table row ${item.level == this.activeLevel ? "active" : ""}`}>
-                      <div className="flex-row first">
-                        <a onclick={() => setLevel(item.level)}>
-                          {item.level}
-                        </a>
-                      </div>
-                      <div className="flex-row second code">
-                        {item.name}
-                      </div>
-                      <div className="flex-row third">
-                        <a onclick={() => open(item.file, item.line-1)}>{item.shortpath}:{item.line || '?'}</a>
-                      </div>
-                    </div>
+               <div className="flex-row first">
+                 <a onclick={() => setLevel(item.level)}>
+                   {item.level}
+                 </a>
+               </div>
+               <div className="flex-row second code">
+                 {item.name}
+               </div>
+               <div className="flex-row third">
+                 <a onclick={() => open(item.file, item.line-1)}>{item.shortpath}:{item.line || '?'}</a>
+               </div>
+             </div>
           })}
         </div>
       </div>

--- a/styles/debugger.less
+++ b/styles/debugger.less
@@ -21,20 +21,30 @@
   .debugger-editor {
     pointer-events: none;
     border-bottom: 1px solid @base-border-color;
+    padding-bottom: 1em;
   }
+
   .item {
     border-bottom: 1px solid @base-border-color;
   }
 
   .toolbar {
-    padding-left: 1em;
-    padding-right: 0.5em;
+    padding: 0em 1em 0.5em 1em;
     line-height: 2.6em;
-    height: 125px;
     max-height: 125px;
 
-    .flex-table-container {
-      padding: 0;
+    .inner-toolbar {
+      display: inline-block;
+      .flex-table-container {
+        padding: 0;
+        position: absolute;
+        right: @component-padding;
+        top: @component-padding;
+        display: inline;
+        .flex-row {
+          padding-left: 0px;
+        }
+      }
     }
 
     .next-expression {
@@ -114,9 +124,8 @@
     }
   }
 
-
   .flex-table-container {
-    padding: 1em;
+    padding: 0.5em 1em 1em 1em;
     .flex-table {
       display: flex;
       .flex-row {
@@ -140,7 +149,7 @@
   .header {
     justify-content: space-between;
     display: flex;
-    padding: 1em 1em 0.7em 1em;
+    padding: 0.5em 1em 0em 1em;
     // background-color: mix(@background-color-highlight, @base-background-color, 40%);
 
     h4 {


### PR DESCRIPTION
- move compile mode button into the right of stepping toolbar
     * (to me, putting compile mode button under the "next expression" seemed less intuitive)
- clearer description for compile mode
- show next expression/callstack only in debugging
- some other small style tweaks

***

not in debugging:
![image](https://user-images.githubusercontent.com/40514306/64526203-a0750480-d33d-11e9-9905-f7e9cee1e6c7.png)

in debugging
![image](https://user-images.githubusercontent.com/40514306/64526216-ab2f9980-d33d-11e9-874c-b3d5622afb46.png)

