### PR TITLE
debugger style tweaks

### DIFF
--- a/lib/debugger/debugger-pane.js
+++ b/lib/debugger/debugger-pane.js
@@ -146,7 +146,7 @@ export default class DebuggerPane extends PaneItem {
 
     const codeHidden = !(this.info.code && this.info.code.length > 0)
     const callstackHidden = this.stack.length === 0
-    return <div className="item">
+    return <div className={"item " + (codeHidden && callstackHidden ? 'hidden' : '') }>
       <div className={"debugger-editor " + (codeHidden ? "hidden" : "")}>
         <div className="header">
           <h4>Current code</h4>
@@ -188,6 +188,10 @@ export default class DebuggerPane extends PaneItem {
       this.breakpointManager.toggleAllActive(this.allActive)
       this.allActive = !this.allActive
     }
+
+    const fileBreakpoints = this.breakpointManager.getFileBreakpoints()
+    const funcBreakpoints = this.breakpointManager.getFuncBreakpoints()
+    const shouldShowHr = fileBreakpoints.length > 0 && funcBreakpoints.length > 0
 
     return  <div className="item ink-breakpoint-container">
               <div className="header">
@@ -246,13 +250,13 @@ export default class DebuggerPane extends PaneItem {
                   </div>
                 </div>
                 {
-                  this.breakpointManager.getFileBreakpoints().map(bp => {
+                  fileBreakpoints.map(bp => {
                     return this.breakpointView(bp)
                   })
                 }
-                <hr></hr>
+                <hr className={shouldShowHr ? '' : 'hidden'}></hr>
                 {
-                  this.breakpointManager.getFuncBreakpoints().map(bp => {
+                  funcBreakpoints.map(bp => {
                     return this.breakpointView(bp)
                   })
                 }

--- a/lib/debugger/toolbar.js
+++ b/lib/debugger/toolbar.js
@@ -25,7 +25,8 @@ export class DebuggerToolbar {
     this.subs.add(atom.tooltips.add(btn, {
       title: tooltip,
       placement: 'top',
-      class: 'ink-toolbar-tooltip'
+      class: 'ink-toolbar-tooltip',
+      keyBindingCommand: command
     }))
     return btn
   }

--- a/styles/debugger.less
+++ b/styles/debugger.less
@@ -31,16 +31,15 @@
   .toolbar {
     padding: 0em 1em 0.5em 1em;
     line-height: 2.6em;
-    max-height: 125px;
 
     .inner-toolbar {
-      display: inline-block;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+
       .flex-table-container {
-        padding: 0;
-        position: absolute;
         right: @component-padding;
         top: @component-padding;
-        display: inline;
         .flex-row {
           padding-left: 0px;
         }
@@ -76,8 +75,9 @@
     .ink-debug-toolbar {
       position: relative;
       transform: none;
-      left: 0;
       background-color: inherit;
+      position: inherit;
+      min-width: inherit;
 
       .code {
         font-family: var(--editor-font-family);
@@ -149,8 +149,9 @@
   .header {
     justify-content: space-between;
     display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
     padding: 0.5em 1em 0em 1em;
-    // background-color: mix(@background-color-highlight, @base-background-color, 40%);
 
     h4 {
       line-height: 2em;


### PR DESCRIPTION
This hides a couple of extra `hr`s and `border-bottom`s, makes the `Compiled Mode` button reflow correctly for narrow panes, and adds keybindings to the toolbar buttons (as indicated in https://github.com/JunoLab/atom-julia-client/pull/613#issuecomment-531129915).