### PR TITLE
fixed an issue where breakpoints get cut off on macOS

### DIFF
--- a/styles/debugger.less
+++ b/styles/debugger.less
@@ -176,6 +176,7 @@ atom-text-editor.editor{
 
       &.icon {
         color: @background-color-error;
+        position: fixed;
         &.inactive {
           color: mix(@background-color-error, @syntax-background-color, 50%);
         }


### PR DESCRIPTION
Fixed an issue where breakpoints get cut off when using the small size of fonts on macOS.

before:
<img width="113" alt="before" src="https://user-images.githubusercontent.com/38322494/70849236-f74f2480-1ebe-11ea-8c78-e83fef4aa2c9.png">
after:
<img width="114" alt="after" src="https://user-images.githubusercontent.com/38322494/70849237-f918e800-1ebe-11ea-92c0-c9f43b50ca36.png">


