### PR TITLE
error handling for the webgl backend

### DIFF
--- a/lib/console/view.js
+++ b/lib/console/view.js
@@ -26,7 +26,12 @@ class TerminalElement extends HTMLElement {
     this.model.terminal.open(this)
 
     if (this.model.isWebgl) {
-      this.model.terminal.loadAddon(new WebglAddon())
+      try {
+        this.model.terminal.loadAddon(new WebglAddon())
+      } catch (err) {
+        console.error('Tried to start terminal with WebGL backend, but encountered the following error:')
+        console.error(err)
+      }
     }
 
     this.subs.add(atom.config.observe('editor.fontSize', (val) => {


### PR DESCRIPTION
Should fix/work around the 
```
layout.js? [sm]:91 Error: WebGL2 not supported
    at new e (WebglRenderer.ts:88)
    at t.activate (WebglAddon.ts:32)
    at e.loadAddon (AddonManager.ts:49)
    at e.loadAddon (Terminal.ts:180)
    at HTMLElement.initialize (view.js? [sm]:9)
    at console.js? [sm]:22
    at Function.simpleDispatch (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Emitter.emit (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Workspace.didActivatePaneContainer (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Dock.subscriptions.l.paneContainer.onDidActivatePane (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Function.simpleDispatch (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Emitter.emit (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at PaneContainer.didActivatePane (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Pane.activate (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Workspace.open (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
(anonymous) @ layout.js? [sm]:91
misc.coffee? [sm]:30 Julia Boot: 32.77s
```
issue @nreigl posted on Slack the other day. 