### PR TITLE
center bg message for outline.js

### DIFF
--- a/lib/outline/outline.js
+++ b/lib/outline/outline.js
@@ -76,9 +76,9 @@ export default class Outline extends PaneItem {
             )
           }
         </table>
-        <div className={hasItems ? 'hidden' : 'center'}>
-          No outline for this editor.
-        </div>
+        <ul className={hasItems ? 'hidden' : 'background-message centered'}>
+          <li>No outline for this editor.</li>
+        </ul>
       </div>
     </div>
   }

--- a/styles/outline.less
+++ b/styles/outline.less
@@ -37,13 +37,6 @@
     overflow: auto;
     height: 100%;
 
-    .center {
-      padding-top: 1em;
-      text-align: center;
-      width: 100%;
-      font-family: system-ui;
-    }
-
     table {
       font-family: var(--editor-font-family);
       font-size: var(--editor-font-size);
@@ -67,6 +60,10 @@
           display: inline-block;
         }
       }
+    }
+
+    .background-message.centered {
+      white-space: normal;
     }
   }
 }


### PR DESCRIPTION
when pane width isn't enough
| before                                                                                                         | after                                                                                                          |
|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/40514306/78093809-fe6a5600-740d-11ea-84d2-eab700f9032f.png) | ![image](https://user-images.githubusercontent.com/40514306/78093139-7cc5f880-740c-11ea-8aa5-9e06dad7fd56.png) |

with enough width
| before                                                                                                         | after                                                                                                          |
|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/40514306/78093986-5e60fc80-740e-11ea-8fab-c266bda5d075.png) | ![image](https://user-images.githubusercontent.com/40514306/78094011-73d62680-740e-11ea-900f-f6441a3bf0ae.png) |