### PR TITLE
Fix deprecation warning in Atom 1.56.0

### DIFF
--- a/lib/console/console.js
+++ b/lib/console/console.js
@@ -13,7 +13,7 @@ import TerminalElement from './view'
 import PaneItem from '../util/pane-item'
 import { debounce, throttle } from 'underscore-plus'
 import { closest } from './helpers'
-import { openExternal } from 'shell'
+import { shell } from 'electron'
 import SearchUI from './searchui'
 
 let getTerminal = el => closest(el, 'ink-terminal').getModel()
@@ -101,7 +101,7 @@ export default class InkTerminal extends PaneItem {
     this.terminal = new Terminal(opts)
     const webLinksAddon = new WebLinksAddon((ev, uri) => {
       if (!this.shouldOpenLink(ev)) return false
-      openExternal(uri)
+      shell.openExternal(uri)
     }, {
       willLinkActivate: ev => this.shouldOpenLink(ev),
       tooltipCallback: (ev, uri, location) => this.tooltipCallback(ev, uri, location),


### PR DESCRIPTION
The 'shell' module is deprecated since the Electron upgrade in Atom 1.56.