### PR TITLE
Fix `subs` is not defined

### DIFF
--- a/lib/linter/compiled-pane.js
+++ b/lib/linter/compiled-pane.js
@@ -7,6 +7,8 @@ import { CompositeDisposable } from 'atom'
 import PaneItem from '../util/pane-item'
 import { open } from '../util/opener'
 
+var subs
+
 // pane for side-to-side view of compiled code and source code
 export default class CompiledPane extends PaneItem {
   name = 'CompiledPane'

--- a/lib/linter/compiled-pane.js
+++ b/lib/linter/compiled-pane.js
@@ -7,18 +7,16 @@ import { CompositeDisposable } from 'atom'
 import PaneItem from '../util/pane-item'
 import { open } from '../util/opener'
 
-var subs
-
 // pane for side-to-side view of compiled code and source code
 export default class CompiledPane extends PaneItem {
   name = 'CompiledPane'
 
   static activate () {
-    subs = new CompositeDisposable()
+    this.subs = new CompositeDisposable()
   }
 
   static deactivate () {
-    subs.dispose()
+    this.subs.dispose()
   }
 
   constructor (opts) {

--- a/lib/linter/pane.js
+++ b/lib/linter/pane.js
@@ -7,6 +7,8 @@ import { CompositeDisposable } from 'atom'
 import PaneItem from '../util/pane-item'
 import { open } from '../util/opener'
 
+var subs
+
 export default class LinterPane extends PaneItem {
   name = 'LinterPane'
 

--- a/lib/linter/pane.js
+++ b/lib/linter/pane.js
@@ -7,17 +7,15 @@ import { CompositeDisposable } from 'atom'
 import PaneItem from '../util/pane-item'
 import { open } from '../util/opener'
 
-var subs
-
 export default class LinterPane extends PaneItem {
   name = 'LinterPane'
 
   static activate () {
-    subs = new CompositeDisposable()
+    this.subs = new CompositeDisposable()
   }
 
   static deactivate () {
-    subs.dispose()
+    this.subs.dispose()
   }
 
   constructor (opts) {


### PR DESCRIPTION
Since Atom was killed the community came together and made a fork called [Pulsar](https://github.com/pulsar-edit/pulsar).
It has updated a lot of parts in the editor.

While most packages still work some old javascript styles are not valid anymore.
This fixes a syntax error.

It would be nice if a new version with this fix could be [published to the new packend](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#publishing). If there are any problems you can create an issue on the github repo.